### PR TITLE
Fix incorrect tooltip showing on Auto Scale Tiles option

### DIFF
--- a/Localization/Language.Designer.cs
+++ b/Localization/Language.Designer.cs
@@ -88,6 +88,15 @@ namespace Amplitude.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You can use your own size for each tile or set them to fill the window automatically.
+        /// </summary>
+        internal static string AutoScaleTilesExplanation {
+            get {
+                return ResourceManager.GetString("AutoScaleTilesExplanation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Auto scale tiles to fit window.
         /// </summary>
         internal static string AutoScaleTilesToWindowLabel {

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -333,4 +333,7 @@
   <data name="AutoScaleTilesToWindowLabel" xml:space="preserve">
     <value>Auto scale tiles to fit window</value>
   </data>
+  <data name="AutoScaleTilesExplanation" xml:space="preserve">
+    <value>You can use your own size for each tile or set them to fill the window automatically</value>
+  </data>
 </root>

--- a/Views/GlobalSettings.axaml
+++ b/Views/GlobalSettings.axaml
@@ -152,7 +152,7 @@
             </Border.BorderBrush>
             <StackPanel>
               <Label Content="{i18n:Localize GridTileSizeLabel}" HorizontalAlignment="Center" Height="30"></Label>
-              <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize CacheAudioExplanation}">
+              <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize AutoScaleTilesExplanation}">
                 <Label Grid.Column="0" VerticalAlignment="Center" Margin="5,0,5,0" HorizontalAlignment="Center" Content="{i18n:Localize AutoScaleTilesToWindowLabel}" ></Label>
                 <CheckBox x:Name="chk_AutoScaleTiles" Grid.Column="1" HorizontalAlignment="Center" Margin="5,0,5,0" VerticalAlignment="Center" IsChecked="{Binding Model.AutoScaleTilesToWindow}" Cursor="Hand"/>
               </Grid>


### PR DESCRIPTION
The "Auto Scale Tiles" option tooltip was showing an explanation about audio caching. This PR creates a new localization string describing what this option is really about.