### PR TITLE
Feature/42 output profiles

### DIFF
--- a/AmplitudeSoundboard.csproj
+++ b/AmplitudeSoundboard.csproj
@@ -50,6 +50,9 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Language.resx</DependentUpon>
     </Compile>
+    <Compile Update="Views\EditOutputProfile.axaml.cs">
+      <DependentUpon>EditOutputProfile.axaml</DependentUpon>
+    </Compile>
     <Compile Update="Views\UpdatePrompt.axaml.cs">
       <DependentUpon>UpdatePrompt.axaml</DependentUpon>
     </Compile>

--- a/AmplitudeSoundboard.csproj
+++ b/AmplitudeSoundboard.csproj
@@ -11,7 +11,7 @@
     <OutputType>WinExe</OutputType>
     <!--<TargetFramework Condition="'$(Windows)'=='false'">net5.0</TargetFramework>
     <TargetFramework Condition="'$(Windows)'=='true'">net5.0-windows</TargetFramework>-->
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Authors>dan0v</Authors>
     <Description>A sleek soundboard</Description>
     <Nullable>enable</Nullable>

--- a/AmplitudeSoundboard.csproj
+++ b/AmplitudeSoundboard.csproj
@@ -35,14 +35,14 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.17" />
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.17" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.17" />
+    <PackageReference Include="Avalonia" Version="0.10.18" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.18" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.10.18" />
     <PackageReference Include="ManagedBass" Version="3.1.1" />
     <PackageReference Include="ManagedBass.Flac" Version="3.1.1" />
     <PackageReference Include="ManagedBass.Mix" Version="3.1.1" />
     <PackageReference Include="ManagedBass.Opus" Version="3.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Localization\Language.Designer.cs">

--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -56,6 +56,7 @@ namespace AmplitudeSoundboard
         }
 
         public static SoundClipManager SoundClipManager => SoundClipManager.Instance;
+        public static OutputProfileManager OutputProfileManager => OutputProfileManager.Instance;
         public static HotkeysManager HotkeysManager => HotkeysManager.Instance;
         public static ThemeHandler ThemeHandler => ThemeHandler.Instance;
         public static WindowManager WindowManager => WindowManager.Instance;
@@ -108,9 +109,10 @@ namespace AmplitudeSoundboard
                 };
 
                 // Initialize managers to make sure they are active
-                var se = SoundEngine;
+                var e = SoundEngine;
                 var k = KeyboardHook;
                 var o = OptionsManager;
+                var p = OutputProfileManager;
                 var s = SoundClipManager;
                 var h = HotkeysManager;
                 var t = ThemeHandler;

--- a/Helpers/BrowseIO.cs
+++ b/Helpers/BrowseIO.cs
@@ -120,7 +120,7 @@ namespace Amplitude.Helpers
                 {
                     if (clip != null)
                     {
-                        App.WindowManager.ShowErrorSoundClip(clip, ViewModels.ErrorListViewModel.ErrorType.MISSING_AUDIO_FILE);
+                        App.WindowManager.ShowErrorSoundClip(clip, ViewModels.ErrorListViewModel.SoundClipErrorType.MISSING_AUDIO_FILE);
                     }
                     else
                     {
@@ -142,7 +142,7 @@ namespace Amplitude.Helpers
                 {
                     if (clip != null)
                     {
-                        App.WindowManager.ShowErrorSoundClip(clip, ViewModels.ErrorListViewModel.ErrorType.BAD_AUDIO_FORMAT);
+                        App.WindowManager.ShowErrorSoundClip(clip, ViewModels.ErrorListViewModel.SoundClipErrorType.BAD_AUDIO_FORMAT);
                     }
                     else
                     {

--- a/Helpers/ISoundEngine.cs
+++ b/Helpers/ISoundEngine.cs
@@ -34,6 +34,7 @@ namespace Amplitude.Helpers
         public ObservableCollection<SoundClip> Queued { get; }
 
         public const string DEFAULT_DEVICE_NAME = "Default";
+        [Obsolete]
         public const string GLOBAL_DEFAULT_DEVICE_NAME = "Global setting";
 
         public void AddToQueue(SoundClip source);

--- a/Helpers/ISoundEngine.cs
+++ b/Helpers/ISoundEngine.cs
@@ -40,7 +40,7 @@ namespace Amplitude.Helpers
 
         public void Play(SoundClip source);
 
-        public void CheckDeviceExistsAndGenerateErrors(SoundClip clip);
+        public void CheckDeviceExistsAndGenerateErrors(OutputProfile outputProfile);
 
         public List<string> OutputDeviceListWithoutGlobal { get; }
 

--- a/Helpers/JSONIOManager.cs
+++ b/Helpers/JSONIOManager.cs
@@ -19,7 +19,6 @@
     along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-using Amplitude.Helpers;
 using AmplitudeSoundboard;
 using Newtonsoft.Json;
 using System;
@@ -30,7 +29,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
-namespace Amplitude.Models
+namespace Amplitude.Helpers
 {
     public class JSONIOManager
     {
@@ -44,7 +43,7 @@ namespace Amplitude.Models
             try
             {
                 var obj = JsonConvert.DeserializeObject(json, typeof(Dictionary<string, T>));
-                return obj == null ? null : (Dictionary<string, T> ?) obj;
+                return obj == null ? null : (Dictionary<string, T>?)obj;
             }
             catch (Exception e)
             {

--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -143,7 +143,7 @@ namespace Amplitude.Helpers
         {
             lock(queueLock)
             {
-                Queued.Add(source.CreateCopy());
+                Queued.Add(source.ShallowCopy());
             }
         }
 

--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -155,13 +155,13 @@ namespace Amplitude.Helpers
 
             foreach (OutputSettings settings in source.OutputSettingsFromProfile)
             {
-                Play(source.AudioFilePath, settings.Volume, settings.DeviceName, source.Name);
+                Play(source.AudioFilePath, settings.Volume, source.Volume, settings.DeviceName, source.Name);
             }
         }
 
-        private void Play(string fileName, int volume, string playerDeviceName, string? name = null)
+        private void Play(string fileName, int volume, float volumeMultiplier, string playerDeviceName, string? name = null)
         {
-            double vol = volume / 100.0;
+            double vol = (volume / 100.0) * (volumeMultiplier / 100);
 
             int? devId = GetOutputPlayerByName(playerDeviceName);
 

--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -228,15 +228,15 @@ namespace Amplitude.Helpers
             }
         }
 
-        public void CheckDeviceExistsAndGenerateErrors(SoundClip clip)
+        public void CheckDeviceExistsAndGenerateErrors(OutputProfile profile)
         {
-            foreach (OutputSettings settings in clip.OutputSettings)
+            foreach (OutputSettings settings in profile.OutputSettings)
             {
                 if (GetOutputPlayerByName(settings.DeviceName) == null)
                 {
-                    if (clip != null)
+                    if (profile != null)
                     {
-                        App.WindowManager.ShowErrorSoundClip(clip, ViewModels.ErrorListViewModel.ErrorType.MISSING_DEVICE, settings.DeviceName);
+                        App.WindowManager.ShowErrorSoundClip(profile, ViewModels.ErrorListViewModel.SoundClipErrorType.MISSING_DEVICE, settings.DeviceName);
                     }
                 }
             }

--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -154,7 +154,7 @@ namespace Amplitude.Helpers
                 return;
             }
 
-            foreach (OutputSettings settings in source.OutputSettings)
+            foreach (OutputSettings settings in source.OutputSettingsFromProfile)
             {
                 Play(source.AudioFilePath, settings.Volume, settings.DeviceName, source.Name);
             }
@@ -236,7 +236,7 @@ namespace Amplitude.Helpers
                 {
                     if (profile != null)
                     {
-                        App.WindowManager.ShowErrorSoundClip(profile, ViewModels.ErrorListViewModel.SoundClipErrorType.MISSING_DEVICE, settings.DeviceName);
+                        App.WindowManager.ShowErrorOutputProfile(profile, ViewModels.ErrorListViewModel.OutputProfileErrorType.MISSING_DEVICE, settings.DeviceName);
                     }
                 }
             }

--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -96,7 +96,6 @@ namespace Amplitude.Helpers
             get
             {
                 List<string> devices = new List<string>();
-                devices.Add(ISoundEngine.GLOBAL_DEFAULT_DEVICE_NAME);
                 // Index 0 is "No Sound", so skip
                 for (int dev = 1; dev < Bass.DeviceCount; dev++)
                 {
@@ -111,7 +110,7 @@ namespace Amplitude.Helpers
         {
             if (playerDeviceName == ISoundEngine.GLOBAL_DEFAULT_DEVICE_NAME)
             {
-                playerDeviceName = App.OptionsManager.Options.OutputSettings.DeviceName;
+                playerDeviceName = ISoundEngine.DEFAULT_DEVICE_NAME;
             }
 
             if (playerDeviceName == ISoundEngine.DEFAULT_DEVICE_NAME || playerDeviceName == "System default")

--- a/Helpers/WindowManager.cs
+++ b/Helpers/WindowManager.cs
@@ -244,7 +244,21 @@ namespace Amplitude.Helpers
             ShowErrorListWindow();
         }
 
-        public void ShowErrorSoundClip(SoundClip clip, ErrorListViewModel.ErrorType errorType, string? additionalData = null)
+        public void ShowErrorOutputProfile(OutputProfile profile, ErrorListViewModel.OutputProfileErrorType errorType, string? additionalData = null)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    ShowErrorOutputProfile(profile, errorType, additionalData);
+                });
+                return;
+            }
+            ((ErrorListViewModel)ErrorListWindow.DataContext)?.AddErrorOutputProfile(profile, errorType, additionalData);
+            ShowErrorListWindow();
+        }
+
+        public void ShowErrorSoundClip(SoundClip clip, ErrorListViewModel.SoundClipErrorType errorType, string? additionalData = null)
         {
             if (!Dispatcher.UIThread.CheckAccess())
             {

--- a/Helpers/WindowManager.cs
+++ b/Helpers/WindowManager.cs
@@ -93,7 +93,7 @@ namespace Amplitude.Helpers
 
         public double DesktopScaling { get => MainWindow?.PlatformImpl.DesktopScaling ?? 1; }
 
-        public string OpenEditOutputProfileWindow(string? Id = null)
+        public void OpenEditOutputProfileWindow(string? Id = null)
         {
             if (Id != null && EditOutputProfileWindows.TryGetValue(Id, out EditOutputProfile window))
             {
@@ -102,7 +102,6 @@ namespace Amplitude.Helpers
                     window.WindowState = WindowState.Normal;
                 }
                 window.Activate();
-                return Id;
             }
             else
             {
@@ -122,10 +121,16 @@ namespace Amplitude.Helpers
                     outputProf.Position = new PixelPoint(pos.Value.X + randomizer.Next(50, 100), pos.Value.Y + randomizer.Next(50, 100));
                 }
 
-                var id = ((EditOutputProfileViewModel?)outputProf.DataContext)?.Model.Id;
-                EditOutputProfileWindows.Add(id, outputProf);
                 outputProf.Show();
-                return id;
+            }
+        }
+
+        public void OpenedEditOutputProfileWindow(string id, EditOutputProfile editOutputProfile)
+        {
+            if (!string.IsNullOrEmpty(id) && !EditOutputProfileWindows.ContainsKey(id))
+            {
+                EditOutputProfileWindows.Add(id, editOutputProfile);
+                OnPropertyChanged(nameof(EditOutputProfileWindows));
             }
         }
 

--- a/Helpers/WindowManager.cs
+++ b/Helpers/WindowManager.cs
@@ -525,7 +525,7 @@ namespace Amplitude.Helpers
                 if (App.OptionsManager.Options.AutoScaleTilesToWindow && lastMainWindowSize != newWindowSize)
                 {
                     lastMainWindowSize = newWindowSize;
-                    App.SoundClipManager.RescaleAllBackgroundImages(true);
+                    App.SoundClipManager.RescaleAllBackgroundImages();
                 }
             }
 

--- a/Localization/Language.Designer.cs
+++ b/Localization/Language.Designer.cs
@@ -538,6 +538,15 @@ namespace Amplitude.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Output Profile &quot;{0}&quot; is missing and cannot be used for playback!.
+        /// </summary>
+        internal static string MissingOutputProfileString {
+            get {
+                return ResourceManager.GetString("MissingOutputProfileString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New sound clip.
         /// </summary>
         internal static string NewSoundClip {
@@ -588,6 +597,15 @@ namespace Amplitude.Localization {
         internal static string OutputDeviceLabel {
             get {
                 return ResourceManager.GetString("OutputDeviceLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Output Profile &quot;{0}&quot; has errors:\\n{1}.
+        /// </summary>
+        internal static string OutputProfileError {
+            get {
+                return ResourceManager.GetString("OutputProfileError", resourceCulture);
             }
         }
         

--- a/Localization/Language.Designer.cs
+++ b/Localization/Language.Designer.cs
@@ -322,6 +322,15 @@ namespace Amplitude.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Edit output profile.
+        /// </summary>
+        internal static string EditOutputProfileTooltip {
+            get {
+                return ResourceManager.GetString("EditOutputProfileTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit Sound Clip.
         /// </summary>
         internal static string EditSoundClipTitle {
@@ -552,6 +561,15 @@ namespace Amplitude.Localization {
         internal static string MissingOutputProfileString {
             get {
                 return ResourceManager.GetString("MissingOutputProfileString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create new output profile.
+        /// </summary>
+        internal static string NewOutputProfileTooltip {
+            get {
+                return ResourceManager.GetString("NewOutputProfileTooltip", resourceCulture);
             }
         }
         

--- a/Localization/Language.Designer.cs
+++ b/Localization/Language.Designer.cs
@@ -313,6 +313,15 @@ namespace Amplitude.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Edit Output Profile.
+        /// </summary>
+        internal static string EditOutputProfileTitle {
+            get {
+                return ResourceManager.GetString("EditOutputProfileTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit Sound Clip.
         /// </summary>
         internal static string EditSoundClipTitle {
@@ -606,6 +615,24 @@ namespace Amplitude.Localization {
         internal static string OutputProfileError {
             get {
                 return ResourceManager.GetString("OutputProfileError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output Profile.
+        /// </summary>
+        internal static string OutputProfileLabel {
+            get {
+                return ResourceManager.GetString("OutputProfileLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output profile name.
+        /// </summary>
+        internal static string OutputProfileNameLabel {
+            get {
+                return ResourceManager.GetString("OutputProfileNameLabel", resourceCulture);
             }
         }
         

--- a/Localization/Language.es.resx
+++ b/Localization/Language.es.resx
@@ -366,4 +366,25 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>En caso de que una ventana esté fuera de alcance, restablezca los tamaños y posiciones de la ventana</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">
+    <value>¡Falta el perfil de salida "{0}" y no se puede utilizar para la reproducción!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>El perfil de salida "{0}" tiene errores:\\n{1}</value>
+  </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Editar perfil de salida</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Nombre del perfil de salida</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Perfil de salida</value>
+  </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Editar perfil de salida</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Crear nuevo perfil de salida</value>
+  </data>
 </root>

--- a/Localization/Language.hu.resx
+++ b/Localization/Language.hu.resx
@@ -366,4 +366,25 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>Ha egy ablak nem elérhető, állítsa vissza az ablak méretét és pozícióját</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">
+    <value>A "{0}" kimeneti profil hiányzik és nem használható a lejátszáshoz!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>A "{0}" kimeneti profil hibás:\\n{1}</value>
+  </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Kimeneti Profil Szerkesztése</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Kimeneti profil neve</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Kimeneti profil</value>
+  </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Kimeneti profil szerkesztése</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Új kimeneti profil</value>
+  </data>
 </root>

--- a/Localization/Language.it.resx
+++ b/Localization/Language.it.resx
@@ -366,4 +366,25 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>Nel caso in cui una finestra sia fuori portata, ripristinare le dimensioni e le posizioni della finestra</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">
+    <value>Il profilo di uscita "{0}" è mancante e non può essere utilizzato per la riproduzione!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>Il profilo di uscita "{0}" ha degli errori:\\n{1}</value>
+  </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Modifica profilo di uscita</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Nome del profilo di uscita</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Profilo di uscita</value>
+  </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Modifica profilo di uscita</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Creare un nuovo profilo di uscita</value>
+  </data>
 </root>

--- a/Localization/Language.nl.resx
+++ b/Localization/Language.nl.resx
@@ -366,4 +366,25 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>Als een raam buiten bereik is, stel dan de venstergrootte en positie opnieuw in</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">
+    <value>Het uitvoerprofiel "{0}" ontbreekt en kan niet worden gebruikt om af te spelen!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>Het uitvoerprofiel "{0}" heeft fouten:\\n{1}</value>.
+  </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Bewerk uitvoerprofiel</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Naam uitvoerprofiel</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Uitvoerprofiel</value>
+  </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Bewerk uitvoerprofiel</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Nieuw uitvoerprofiel aanmaken</value>
+  </data>
 </root>

--- a/Localization/Language.pl.resx
+++ b/Localization/Language.pl.resx
@@ -366,11 +366,11 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>Jeśli okno jest poza zasięgiem, zresetuj rozmiary i pozycje okien</value>
   </data>
-  <data name="MissingOutputProfileString" xml:space="preserve">.
+  <data name="MissingOutputProfileString" xml:space="preserve">
     <value>Brak profilu wyjściowego "{0}" i nie może być użyty do odtwarzania!</value>
   </data>
   <data name="OutputProfileError" xml:space="preserve">
-    <value>Profil wyjściowy "{0}" ma błędy:\\n{1}</value>.
+    <value>Profil wyjściowy "{0}" ma błędy:\\n{1}</value>
   </data>
   <data name="EditOutputProfileTitle" xml:space="preserve">
     <value>Edytuj profil wyjściowy</value>

--- a/Localization/Language.pl.resx
+++ b/Localization/Language.pl.resx
@@ -366,4 +366,25 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>Jeśli okno jest poza zasięgiem, zresetuj rozmiary i pozycje okien</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">.
+    <value>Brak profilu wyjściowego "{0}" i nie może być użyty do odtwarzania!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>Profil wyjściowy "{0}" ma błędy:\\n{1}</value>.
+  </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Edytuj profil wyjściowy</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Edycja profilu wyjściowego</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Nazwa profilu wyjściowego</value>
+  </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Edycja profilu wyjściowego</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Tworzyć nowy profil wyjściowy</value>
+  </data>
 </root>

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -381,4 +381,10 @@
   <data name="OutputProfileLabel" xml:space="preserve">
     <value>Output Profile</value>
   </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Edit output profile</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Create new output profile</value>
+  </data>
 </root>

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -372,4 +372,13 @@
   <data name="OutputProfileError" xml:space="preserve">
     <value>The Output Profile "{0}" has errors:\\n{1}</value>
   </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Edit Output Profile</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Output profile name</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Output Profile</value>
+  </data>
 </root>

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -366,4 +366,10 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>In case a window is out of reach, reset window sizes and positions</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">
+    <value>The Output Profile "{0}" is missing and cannot be used for playback!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>The Output Profile "{0}" has errors:\\n{1}</value>
+  </data>
 </root>

--- a/Localization/Language.ru.resx
+++ b/Localization/Language.ru.resx
@@ -366,4 +366,25 @@
   <data name="ClearPositionsTooltip" xml:space="preserve">
     <value>Если окно находится вне досягаемости, сбросьте размеры и положение окна.</value>
   </data>
+  <data name="MissingOutputProfileString" xml:space="preserve">
+    <value> Профиль вывода "{0}" отсутствует и не может быть использован для воспроизведения!</value>
+  </data>
+  <data name="OutputProfileError" xml:space="preserve">
+    <value>В выходном профиле "{0}" есть ошибки:\\n{1}</value>
+  </data>
+  <data name="EditOutputProfileTitle" xml:space="preserve">
+    <value>Редактировать профиль вывода</value>
+  </data>
+  <data name="OutputProfileNameLabel" xml:space="preserve">
+    <value>Имя выходного профиля</value>
+  </data>
+  <data name="OutputProfileLabel" xml:space="preserve">
+    <value>Выходной профиль</value>
+  </data>
+  <data name="EditOutputProfileTooltip" xml:space="preserve">
+    <value>Редактировать профиль вывода</value>
+  </data>
+  <data name="NewOutputProfileTooltip" xml:space="preserve">
+    <value>Создать новый профиль вывода</value>
+  </data>
 </root>

--- a/Models/ErrorContainer.cs
+++ b/Models/ErrorContainer.cs
@@ -28,14 +28,30 @@ namespace Amplitude.Models
         public string ErrorMessage { get; set; } = "";
         public bool LinkedSoundClip { get; set; } = false;
         public string SoundClipId { get; set; } = "";
+        public bool LinkedOutputProfile { get; set; } = false;
+        public string OutputProfileId { get; set; } = "";
 
-        public ErrorContainer(string errorMessage, string soundClipId = "")
+        public ErrorContainer(string errorMessage)
         {
             this.ErrorMessage = errorMessage;
-            if (!string.IsNullOrEmpty(soundClipId))
+        }
+
+        public ErrorContainer(string errorMessage, SoundClip clip)
+        {
+            this.ErrorMessage = errorMessage;
+            if (!string.IsNullOrEmpty(clip?.Id))
             {
                 this.LinkedSoundClip = true;
-                this.SoundClipId = soundClipId;
+                this.SoundClipId = clip?.Id;
+            }
+        }
+
+        public ErrorContainer(string errorMessage, OutputProfile profile)
+        {
+            if (!string.IsNullOrEmpty(profile?.Id))
+            {
+                this.LinkedOutputProfile = true;
+                this.OutputProfileId = profile?.Id;
             }
         }
 
@@ -44,6 +60,13 @@ namespace Amplitude.Models
             if (App.SoundClipManager.GetClip(SoundClipId) != null)
             {
                 App.WindowManager.OpenEditSoundClipWindow(SoundClipId);
+            }
+        }
+        public void OpenEditOutputProfileWindow()
+        {
+            if (App.SoundClipManager.GetOutputProfile(OutputProfileId) != null)
+            {
+                App.WindowManager.OpenEditOutputProfileWindow(OutputProfileId);
             }
         }
     }

--- a/Models/ErrorContainer.cs
+++ b/Models/ErrorContainer.cs
@@ -48,6 +48,7 @@ namespace Amplitude.Models
 
         public ErrorContainer(string errorMessage, OutputProfile profile)
         {
+            this.ErrorMessage = errorMessage;
             if (!string.IsNullOrEmpty(profile?.Id))
             {
                 this.LinkedOutputProfile = true;
@@ -66,7 +67,7 @@ namespace Amplitude.Models
         {
             if (App.OutputProfileManager.GetOutputProfile(OutputProfileId) != null)
             {
-                // TODO App.WindowManager.OpenEditOutputProfileWindow(OutputProfileId);
+                App.WindowManager.OpenEditOutputProfileWindow(OutputProfileId);
             }
         }
     }

--- a/Models/ErrorContainer.cs
+++ b/Models/ErrorContainer.cs
@@ -64,9 +64,9 @@ namespace Amplitude.Models
         }
         public void OpenEditOutputProfileWindow()
         {
-            if (App.SoundClipManager.GetOutputProfile(OutputProfileId) != null)
+            if (App.OutputProfileManager.GetOutputProfile(OutputProfileId) != null)
             {
-                App.WindowManager.OpenEditOutputProfileWindow(OutputProfileId);
+                // TODO App.WindowManager.OpenEditOutputProfileWindow(OutputProfileId);
             }
         }
     }

--- a/Models/JSONIOManager.cs
+++ b/Models/JSONIOManager.cs
@@ -1,0 +1,84 @@
+﻿/*
+    AmplitudeSoundboard
+    Copyright (C) 2021-2022 dan0v
+    https://git.dan0v.com/AmplitudeSoundboard
+
+    This file is part of AmplitudeSoundboard.
+
+    AmplitudeSoundboard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    AmplitudeSoundboard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using Amplitude.Helpers;
+using AmplitudeSoundboard;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Amplitude.Models
+{
+    public class JSONIOManager
+    {
+        protected static Dictionary<string, T>? ConvertObjectsFromJSON<T>(string? json)
+        {
+            if (string.IsNullOrEmpty(json))
+            {
+                return null;
+            }
+
+            try
+            {
+                var obj = JsonConvert.DeserializeObject(json, typeof(Dictionary<string, T>));
+                return obj == null ? null : (Dictionary<string, T> ?) obj;
+            }
+            catch (Exception e)
+            {
+                App.WindowManager.ShowErrorString(e.Message);
+            }
+            return null;
+        }
+
+        protected static string? RetrieveJSONFromFile(string file)
+        {
+            try
+            {
+                if (File.Exists(Path.Join(App.APP_STORAGE, file)))
+                {
+                    return File.ReadAllText(Path.Join(App.APP_STORAGE, file));
+                }
+            }
+            catch (Exception e)
+            {
+                App.WindowManager.ShowErrorString(e.Message);
+            }
+            return null;
+        }
+
+        protected static void SaveJSONToFile(string file, string json)
+        {
+            try
+            {
+                File.WriteAllText(Path.Join(App.APP_STORAGE, file), json);
+            }
+            catch (Exception e)
+            {
+                App.WindowManager.ShowErrorString(e.Message);
+            }
+        }
+    }
+}

--- a/Models/Options.cs
+++ b/Models/Options.cs
@@ -45,21 +45,6 @@ namespace Amplitude.Models
             }
         }
 
-        private string _theme = "Dark";
-        [Obsolete]
-        public string Theme
-        {
-            internal get => _theme;
-            set
-            {
-                if (value != _theme)
-                {
-                    _theme = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
         private int _themeId = 0;
         public int ThemeId
         {
@@ -70,35 +55,6 @@ namespace Amplitude.Models
                 if (value != -1 && value != _themeId)
                 {
                     _themeId = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
-        [Obsolete]
-        public int MasterVolume
-        {
-            internal get => 100;
-            set { }
-        }
-
-        [Obsolete]
-        public string DefaultOutputDevice
-        {
-            internal get => "";
-            set { }
-        }
-
-        private OutputSettings _outputSettings = new OutputSettings();
-        [Obsolete]
-        public OutputSettings OutputSettings
-        {
-            internal get => _outputSettings;
-            set
-            {
-                if (value != _outputSettings)
-                {
-                    _outputSettings = value;
                     OnPropertyChanged();
                 }
             }
@@ -210,20 +166,6 @@ namespace Amplitude.Models
                     OnPropertyChanged();
                 }
             }
-        }
-
-        [Obsolete]
-        public bool CacheAudio
-        {
-            internal get => false;
-            set { }
-        }
-
-        [Obsolete]
-        public bool PreCacheAudio
-        {
-            internal get => false;
-            set { }
         }
 
         public Options()

--- a/Models/Options.cs
+++ b/Models/Options.cs
@@ -90,9 +90,10 @@ namespace Amplitude.Models
         }
 
         private OutputSettings _outputSettings = new OutputSettings();
+        [Obsolete]
         public OutputSettings OutputSettings
         {
-            get => _outputSettings;
+            internal get => _outputSettings;
             set
             {
                 if (value != _outputSettings)

--- a/Models/OptionsManager.cs
+++ b/Models/OptionsManager.cs
@@ -66,11 +66,6 @@ namespace Amplitude.Models
                 _options = new Options();
             }
 
-            if (string.IsNullOrEmpty(_options.OutputSettings.DeviceName) || _options.OutputSettings.DeviceName == ISoundEngine.GLOBAL_DEFAULT_DEVICE_NAME)
-            {
-                _options.OutputSettings.DeviceName = ISoundEngine.DEFAULT_DEVICE_NAME;
-            }
-
             OnPropertyChanged(nameof(Options));
         }
 

--- a/Models/OutputProfile.cs
+++ b/Models/OutputProfile.cs
@@ -34,7 +34,7 @@ namespace Amplitude.Models
         [JsonIgnore]
         public string Id => _id;
 
-        public void InitializeId(string newId)
+        public void InitializeId(string? newId)
         {
             if (string.IsNullOrEmpty(newId))
             {

--- a/Models/OutputProfile.cs
+++ b/Models/OutputProfile.cs
@@ -29,7 +29,7 @@ namespace Amplitude.Models
 {
     public class OutputProfile : INotifyPropertyChanged
     {
-
+        [JsonIgnore]
         public string Id { get; protected set; }
 
         public void OverrideId(string newId)
@@ -68,12 +68,12 @@ namespace Amplitude.Models
 
         public OutputProfile(Collection<OutputSettings>? settings = null)
         {
-            Id = DateTimeOffset.Now.ToUnixTimeMilliseconds() + "" + GetHashCode();
-
             if (settings != null)
             {
                 OutputSettings = new ObservableCollection<OutputSettings>(settings);
             }
+
+            Id = DateTimeOffset.Now.ToUnixTimeMilliseconds() + "" + GetHashCode();
         }
 
         public string ToJSON()
@@ -81,9 +81,9 @@ namespace Amplitude.Models
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
 
-        public OutputSettings ShallowCopy()
+        public OutputProfile ShallowCopy()
         {
-            return (OutputSettings)this.MemberwiseClone();
+            return (OutputProfile)this.MemberwiseClone();
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/Models/OutputProfile.cs
+++ b/Models/OutputProfile.cs
@@ -1,0 +1,84 @@
+﻿/*
+    AmplitudeSoundboard
+    Copyright (C) 2021-2022 dan0v
+    https://git.dan0v.com/AmplitudeSoundboard
+
+    This file is part of AmplitudeSoundboard.
+
+    AmplitudeSoundboard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    AmplitudeSoundboard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Amplitude.Models
+{
+    public class OutputProfile : INotifyPropertyChanged
+    {
+
+        public string Id { get; protected set; }
+
+        private string _name = "";
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (value != _name)
+                {
+                    _name = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private ObservableCollection<OutputSettings> _outputSettings = new ObservableCollection<OutputSettings>();
+        public ObservableCollection<OutputSettings> OutputSettings
+        {
+            get => _outputSettings;
+            set
+            {
+                if (value != _outputSettings)
+                {
+                    _outputSettings = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public OutputProfile()
+        {
+            Id = DateTimeOffset.Now.ToUnixTimeMilliseconds() + "" + GetHashCode();
+        }
+
+        public string ToJSON()
+        {
+            return JsonConvert.SerializeObject(this, Formatting.Indented);
+        }
+
+        public OutputSettings ShallowCopy()
+        {
+            return (OutputSettings)this.MemberwiseClone();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Models/OutputProfile.cs
+++ b/Models/OutputProfile.cs
@@ -32,6 +32,12 @@ namespace Amplitude.Models
 
         public string Id { get; protected set; }
 
+        public void OverrideId(string newId)
+        {
+            Id = newId;
+            OnPropertyChanged(nameof(Id));
+        }
+
         private string _name = "";
         public string Name
         {
@@ -60,9 +66,14 @@ namespace Amplitude.Models
             }
         }
 
-        public OutputProfile()
+        public OutputProfile(Collection<OutputSettings>? settings = null)
         {
             Id = DateTimeOffset.Now.ToUnixTimeMilliseconds() + "" + GetHashCode();
+
+            if (settings != null)
+            {
+                OutputSettings = new ObservableCollection<OutputSettings>(settings);
+            }
         }
 
         public string ToJSON()

--- a/Models/OutputProfile.cs
+++ b/Models/OutputProfile.cs
@@ -21,6 +21,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -29,13 +30,25 @@ namespace Amplitude.Models
 {
     public class OutputProfile : INotifyPropertyChanged
     {
+        private string _id = null;
         [JsonIgnore]
-        public string Id { get; protected set; }
+        public string Id => _id;
 
-        public void OverrideId(string newId)
+        public void InitializeId(string newId)
         {
-            Id = newId;
-            OnPropertyChanged(nameof(Id));
+            if (string.IsNullOrEmpty(newId))
+            {
+                newId = DateTimeOffset.Now.ToUnixTimeMilliseconds() + "" + GetHashCode();
+            }
+            if (string.IsNullOrEmpty(Id))
+            {
+                _id = newId;
+                OnPropertyChanged(nameof(Id));
+            }
+            else
+            {
+                throw new NotSupportedException("Do not alter Id once it has been set");
+            }
         }
 
         private string _name = "";
@@ -68,12 +81,15 @@ namespace Amplitude.Models
 
         public OutputProfile(Collection<OutputSettings>? settings = null)
         {
-            if (settings != null)
+            if (settings == null)
+            {
+                OutputSettings defaultSettings = new OutputSettings();
+                OutputSettings = new ObservableCollection<OutputSettings>(new List<OutputSettings>() { defaultSettings });
+            }
+            else
             {
                 OutputSettings = new ObservableCollection<OutputSettings>(settings);
             }
-
-            Id = DateTimeOffset.Now.ToUnixTimeMilliseconds() + "" + GetHashCode();
         }
 
         public string ToJSON()

--- a/Models/OutputProfileManager.cs
+++ b/Models/OutputProfileManager.cs
@@ -42,7 +42,7 @@ namespace Amplitude.Models
         private Dictionary<string, OutputProfile> _outputProfiles;
         public Dictionary<string, OutputProfile> OutputProfiles { get => _outputProfiles; }
 
-        public List<string> OutputProfilesList { get => OutputProfiles.Keys.ToList(); }
+        public List<OutputProfile> OutputProfilesList { get => OutputProfiles.Values.ToList(); }
 
         private OutputProfileManager()
         {
@@ -120,6 +120,8 @@ namespace Amplitude.Models
         public void RemoveOutputProfile(string Id)
         {
             OutputProfiles.Remove(Id);
+            OnPropertyChanged(nameof(OutputProfiles));
+            OnPropertyChanged(nameof(OutputProfilesList));
             StoreSavedOutputProfiles();
         }
 

--- a/Models/OutputProfileManager.cs
+++ b/Models/OutputProfileManager.cs
@@ -1,0 +1,145 @@
+﻿/*
+    AmplitudeSoundboard
+    Copyright (C) 2021-2022 dan0v
+    https://git.dan0v.com/AmplitudeSoundboard
+
+    This file is part of AmplitudeSoundboard.
+
+    AmplitudeSoundboard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    AmplitudeSoundboard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using Amplitude.Helpers;
+using AmplitudeSoundboard;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Amplitude.Models
+{
+    public class OutputProfileManager : JSONIOManager, INotifyPropertyChanged
+    {
+        private static OutputProfileManager? _instance;
+        public static OutputProfileManager Instance { get => _instance ??= new OutputProfileManager(); }
+        
+        private const string OUTPUTPROFILES_FILE = "profiles.json";
+        public const string DEFAULT_OUTPUTPROFILE = "DEFAULT";
+
+        private Dictionary<string, OutputProfile> _outputProfiles;
+        public Dictionary<string, OutputProfile> OutputProfiles { get => _outputProfiles; }
+
+        public List<string> OutputProfilesList { get => OutputProfiles.Keys.ToList(); }
+
+        private OutputProfileManager()
+        {
+            Dictionary<string, OutputProfile>? retrievedOutputProfiles = RetrieveSavedOutputProfiles();
+
+            if (retrievedOutputProfiles != null)
+            {
+                _outputProfiles = retrievedOutputProfiles;
+            }
+            else
+            {
+                _outputProfiles = new Dictionary<string, OutputProfile>();
+            }
+
+            if (!_outputProfiles.ContainsKey(DEFAULT_OUTPUTPROFILE))
+            {
+                var profile = new OutputProfile();
+                profile.OverrideId(DEFAULT_OUTPUTPROFILE);
+                profile.Name = "Default";
+                profile.OutputSettings.Add(new OutputSettings());
+                AddOutputProfile(profile);
+            }
+        }
+
+        public string FindOrCreateIdOfSimilarOutputProfile(Collection<OutputSettings> settings)
+        {
+            foreach (var profile in OutputProfiles)
+            {
+                var profileDevs = profile.Value.OutputSettings.Select(s => s.DeviceName).ToList();
+                var settingsDevs = settings.Select(s => s.DeviceName);
+                if (settingsDevs.All(s => profileDevs.Contains(s)))
+                {
+                    return profile.Key;
+                }
+            }
+            var newProf = new OutputProfile(settings);
+            AddOutputProfile(newProf);
+            OnPropertyChanged(nameof(OutputProfilesList));
+            return newProf.Id;
+        }
+
+        public void AddOutputProfile(OutputProfile profile)
+        {
+            OutputProfiles.Add(profile.Id, profile);
+            StoreSavedOutputProfiles();
+        }
+
+        private void StoreSavedOutputProfiles()
+        {
+            string profilesInJson = ConvertOutputProfilesToJSON();
+
+            SaveJSONToFile(OUTPUTPROFILES_FILE, profilesInJson);
+        }
+
+        private string ConvertOutputProfilesToJSON()
+        {
+            return JsonConvert.SerializeObject(OutputProfiles, Formatting.Indented);
+        }
+
+        public void ValidateOutputProfile(OutputProfile profile)
+        {
+            foreach (OutputSettings settings in profile.OutputSettings)
+            {
+                if (string.IsNullOrEmpty(settings.DeviceName) || settings.DeviceName == "DEFAULT")
+                {
+                    settings.DeviceName = ISoundEngine.GLOBAL_DEFAULT_DEVICE_NAME;
+                }
+            }
+        }
+
+        public OutputProfile? GetOutputProfile(string? id, bool ignoreErrors = false)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return null;
+            }
+
+            if (OutputProfiles.TryGetValue(id, out OutputProfile? profile))
+            {
+                return profile;
+            }
+            if (!ignoreErrors)
+            {
+                App.WindowManager.ShowErrorString("OutputProfile with ID: " + id + " does not exist!");
+            }
+            return null;
+        }
+
+        private static Dictionary<string, OutputProfile>? RetrieveSavedOutputProfiles()
+        {
+            string? clipsInJson = RetrieveJSONFromFile(OUTPUTPROFILES_FILE);
+            return ConvertObjectsFromJSON<OutputProfile>(clipsInJson);
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Models/OutputProfileManager.cs
+++ b/Models/OutputProfileManager.cs
@@ -83,6 +83,7 @@ namespace Amplitude.Models
             }
             var newProf = new OutputProfile(settings);
             newProf.Name = MIGRATED_PROFILES_NAME_BASE + "_" + migratedProfileCounter++;
+            newProf.InitializeId(null);
             AddOutputProfile(newProf);
             OnPropertyChanged(nameof(OutputProfilesList));
             return newProf.Id;

--- a/Models/OutputSettings.cs
+++ b/Models/OutputSettings.cs
@@ -44,7 +44,7 @@ namespace Amplitude.Models
             }
         }
 
-        private string _deviceName = ISoundEngine.GLOBAL_DEFAULT_DEVICE_NAME;
+        private string _deviceName = ISoundEngine.DEFAULT_DEVICE_NAME;
         public string DeviceName
         {
             get => _deviceName;

--- a/Models/SoundClip.cs
+++ b/Models/SoundClip.cs
@@ -151,31 +151,23 @@ namespace Amplitude.Models
             }
         }
 
-        // legacy soundclips loading
         private int _volume = 100;
-        [Obsolete]
         public int Volume
         {
-            internal get => _volume;
+            get => _volume;
             set
             {
-                if (OutputSettingsFromProfile.Count <= 0)
+                if (value != _volume)
                 {
-                    OutputSettingsFromProfile.Add(new OutputSettings());
+                    _volume = value;
+                    OnPropertyChanged();
                 }
-                OutputSettingsFromProfile[0].Volume = value;
             }
         }
 
         private ObservableCollection<OutputSettings> _outputSettingsFromProfile = new ObservableCollection<OutputSettings>();
         [JsonIgnore]
-        public ObservableCollection<OutputSettings> OutputSettingsFromProfile
-        {
-            get
-            {
-                return App.OutputProfileManager.GetOutputProfile(OutputProfileId)?.OutputSettings ?? new ObservableCollection<OutputSettings>();
-            }
-        }
+        public ObservableCollection<OutputSettings> OutputSettingsFromProfile => App.OutputProfileManager.GetOutputProfile(OutputProfileId)?.OutputSettings;
 
         private ObservableCollection<OutputSettings> _outputSettings = new ObservableCollection<OutputSettings>();
         [Obsolete]
@@ -209,17 +201,11 @@ namespace Amplitude.Models
         private string _id = null;
         // Do not write to JSON, since it is stored in dictionary anyway
         [JsonIgnore]
-        public string Id
-        {
-            get => _id;
-        }
+        public string Id => _id;
 
         private Bitmap? _backgroundImage = null;
         [JsonIgnore]
-        public Bitmap? BackgroundImage
-        {
-            get => _backgroundImage;
-        }
+        public Bitmap? BackgroundImage => _backgroundImage;
 
         private bool _loadBackgroundImage = false;
         [JsonIgnore]
@@ -318,7 +304,7 @@ namespace Amplitude.Models
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
 
-        public SoundClip CreateCopy()
+        public SoundClip ShallowCopy()
         {
             return (SoundClip)this.MemberwiseClone();
         }

--- a/Models/SoundClip.cs
+++ b/Models/SoundClip.cs
@@ -170,12 +170,29 @@ namespace Amplitude.Models
         private ObservableCollection<OutputSettings> _outputSettings = new ObservableCollection<OutputSettings>();
         public ObservableCollection<OutputSettings> OutputSettings
         {
-            get => _outputSettings;
-            set
+            get
+            {
+                return App.SoundClipManager.GetOutputProfile(OutputProfileId).OutputSettings;
+            }
+            internal set
             {
                 if (value != _outputSettings)
                 {
                     _outputSettings = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private string _outputProfileId = "DEFAULT";
+        public string OutputProfileId
+        {
+            get => _outputProfileId;
+            set
+            {
+                if (value != _outputProfileId)
+                {
+                    _outputProfileId = value;
                     OnPropertyChanged();
                 }
             }
@@ -189,9 +206,9 @@ namespace Amplitude.Models
             get => _id;
         }
 
-        private Bitmap _backgroundImage = null;
+        private Bitmap? _backgroundImage = null;
         [JsonIgnore]
-        public Bitmap BackgroundImage
+        public Bitmap? BackgroundImage
         {
             get => _backgroundImage;
         }
@@ -238,7 +255,7 @@ namespace Amplitude.Models
             App.WindowManager.OpenEditSoundClipWindow(Id);
         }
 
-        public async Task SetAndRescaleBackgroundImage(bool fromBackgroundThread = false)
+        public async Task SetAndRescaleBackgroundImage()
         {
             if (LoadBackgroundImage && BrowseIO.ValidImage(_imageFilePath, false))
             {
@@ -263,28 +280,16 @@ namespace Amplitude.Models
                 _backgroundImage = null;
             }
 
-            void triggerOnChanged()
-            {
-                if (fromBackgroundThread)
-                {
-                    OnPropertyChanged(nameof(BackgroundImage));
-                }
-                else
-                {
-                    OnPropertyChanged(nameof(BackgroundImage));
-                }
-            }
-
             if (!Dispatcher.UIThread.CheckAccess())
             {
                 await Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    triggerOnChanged();
+                    OnPropertyChanged(nameof(BackgroundImage));
                 });
                 return;
             }
 
-            triggerOnChanged();
+            OnPropertyChanged(nameof(BackgroundImage));
         }
 
         public static SoundClip? FromJSON(string json)

--- a/Models/SoundClip.cs
+++ b/Models/SoundClip.cs
@@ -107,20 +107,6 @@ namespace Amplitude.Models
             }
         }
 
-        private bool _preCache = false;
-        public bool PreCache
-        {
-            get => _preCache;
-            set
-            {
-                if (value != _preCache)
-                {
-                    _preCache = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
         private bool _nameVisibleOnGridTile = true;
         public bool NameVisibleOnGridTile
         {
@@ -132,22 +118,6 @@ namespace Amplitude.Models
                     _nameVisibleOnGridTile = value;
                     OnPropertyChanged();
                 }
-            }
-        }
-
-        // legacy soundclips loading
-        private string _deviceName = ISoundEngine.DEFAULT_DEVICE_NAME;
-        [Obsolete]
-        public string DeviceName
-        {
-            internal get => _deviceName;
-            set
-            {
-                if (OutputSettingsFromProfile.Count <= 0)
-                {
-                    OutputSettingsFromProfile.Add(new OutputSettings());
-                }
-                OutputSettingsFromProfile[0].DeviceName = value;
             }
         }
 

--- a/Models/SoundClip.cs
+++ b/Models/SoundClip.cs
@@ -143,11 +143,11 @@ namespace Amplitude.Models
             internal get => _deviceName;
             set
             {
-                if (OutputSettings.Count <= 0)
+                if (OutputSettingsFromProfile.Count <= 0)
                 {
-                    OutputSettings.Add(new OutputSettings());
+                    OutputSettingsFromProfile.Add(new OutputSettings());
                 }
-                OutputSettings[0].DeviceName = value;
+                OutputSettingsFromProfile[0].DeviceName = value;
             }
         }
 
@@ -159,32 +159,39 @@ namespace Amplitude.Models
             internal get => _volume;
             set
             {
-                if (OutputSettings.Count <= 0)
+                if (OutputSettingsFromProfile.Count <= 0)
                 {
-                    OutputSettings.Add(new OutputSettings());
+                    OutputSettingsFromProfile.Add(new OutputSettings());
                 }
-                OutputSettings[0].Volume = value;
+                OutputSettingsFromProfile[0].Volume = value;
+            }
+        }
+
+        private ObservableCollection<OutputSettings> _outputSettingsFromProfile = new ObservableCollection<OutputSettings>();
+        [JsonIgnore]
+        public ObservableCollection<OutputSettings> OutputSettingsFromProfile
+        {
+            get
+            {
+                return App.OutputProfileManager.GetOutputProfile(OutputProfileId)?.OutputSettings ?? new ObservableCollection<OutputSettings>();
             }
         }
 
         private ObservableCollection<OutputSettings> _outputSettings = new ObservableCollection<OutputSettings>();
+        [Obsolete]
         public ObservableCollection<OutputSettings> OutputSettings
         {
-            get
-            {
-                return App.SoundClipManager.GetOutputProfile(OutputProfileId).OutputSettings;
-            }
-            internal set
+            get => _outputSettings;
+            set
             {
                 if (value != _outputSettings)
                 {
                     _outputSettings = value;
-                    OnPropertyChanged();
                 }
             }
         }
 
-        private string _outputProfileId = "DEFAULT";
+        private string _outputProfileId = OutputProfileManager.DEFAULT_OUTPUTPROFILE;
         public string OutputProfileId
         {
             get => _outputProfileId;
@@ -194,6 +201,7 @@ namespace Amplitude.Models
                 {
                     _outputProfileId = value;
                     OnPropertyChanged();
+                    OnPropertyChanged(nameof(OutputSettingsFromProfile));
                 }
             }
         }
@@ -312,15 +320,7 @@ namespace Amplitude.Models
 
         public SoundClip CreateCopy()
         {
-            var copy = (SoundClip)this.MemberwiseClone();
-            copy.OutputSettings = new ObservableCollection<OutputSettings>();
-
-            foreach (var setting in OutputSettings)
-            {
-                copy.OutputSettings.Add(setting.ShallowCopy());
-            }
-
-            return copy;
+            return (SoundClip)this.MemberwiseClone();
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;

--- a/Models/SoundClipManager.cs
+++ b/Models/SoundClipManager.cs
@@ -24,6 +24,7 @@ using AmplitudeSoundboard;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
@@ -102,6 +103,7 @@ namespace Amplitude.Models
             {
                 _soundClips = retrievedClips;
                 InitializeSoundClips(SoundClips);
+                StoreSavedSoundClips();
             }
             else
             {
@@ -118,7 +120,7 @@ namespace Amplitude.Models
                 if (item.Value.OutputSettings.Any())
                 {
                     item.Value.OutputProfileId = App.OutputProfileManager.FindOrCreateIdOfSimilarOutputProfile(item.Value.OutputSettings);
-                    item.Value.OutputSettings = new System.Collections.ObjectModel.ObservableCollection<OutputSettings>();
+                    item.Value.OutputSettings = new ObservableCollection<OutputSettings>();
                 }
 
                 ValidateSoundClip(item.Value);

--- a/Models/SoundClipManager.cs
+++ b/Models/SoundClipManager.cs
@@ -144,13 +144,16 @@ namespace Amplitude.Models
             {
                 App.WindowManager.ShowErrorSoundClip(clip, ViewModels.ErrorListViewModel.SoundClipErrorType.MISSING_IMAGE_FILE);
             }
-
+            
             var profile = App.OutputProfileManager.GetOutputProfile(clip.OutputProfileId);
-            if (profile != null)
+            if (profile == null)
             {
-                App.OutputProfileManager.ValidateOutputProfile(profile);
-                App.SoundEngine.CheckDeviceExistsAndGenerateErrors(profile);
+                clip.OutputProfileId = OutputProfileManager.DEFAULT_OUTPUTPROFILE;
+                profile = App.OutputProfileManager.GetOutputProfile(clip.OutputProfileId);
             }
+
+            App.OutputProfileManager.ValidateOutputProfile(profile);
+            App.SoundEngine.CheckDeviceExistsAndGenerateErrors(profile);
         }
 
         /// <summary>

--- a/Models/SoundClipManager.cs
+++ b/Models/SoundClipManager.cs
@@ -19,6 +19,7 @@
     along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+using Amplitude.Helpers;
 using AmplitudeSoundboard;
 using Newtonsoft.Json;
 using System;

--- a/ViewModels/EditOutputProfileViewModel.cs
+++ b/ViewModels/EditOutputProfileViewModel.cs
@@ -104,13 +104,13 @@ namespace Amplitude.ViewModels
 
         public void DeleteOutputProfile()
         {
-            App.OutputProfileManager.RemoveOutputProfile(Model.Id);
+            OutputProfileManager.RemoveOutputProfile(Model.Id);
         }
 
         public void SaveOutputProfile()
         {
             OutputProfile toSave = Model.ShallowCopy();
-            App.OutputProfileManager.SaveOutputProfile(toSave);
+            OutputProfileManager.SaveOutputProfile(toSave);
             // Copy back and forth to incorporate validations done during saving
             _model = toSave.ShallowCopy();
             OnPropertyChanged(nameof(Model));

--- a/ViewModels/EditOutputProfileViewModel.cs
+++ b/ViewModels/EditOutputProfileViewModel.cs
@@ -1,0 +1,138 @@
+/*
+    AmplitudeSoundboard
+    Copyright (C) 2021-2022 dan0v
+    https://git.dan0v.com/AmplitudeSoundboard
+
+    This file is part of AmplitudeSoundboard.
+
+    AmplitudeSoundboard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    AmplitudeSoundboard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using Amplitude.Models;
+using AmplitudeSoundboard;
+using Avalonia.Media;
+using System.Collections.Generic;
+
+namespace Amplitude.ViewModels
+{
+    public sealed class EditOutputProfileViewModel : ViewModelBase
+    {
+        private OutputProfile _model;
+        public OutputProfile Model => _model;
+
+        private bool _hasNameField;
+        public bool HasNameField
+        {
+            get => _hasNameField;
+            set
+            {
+                if (value != _hasNameField)
+                {
+                    _hasNameField = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        private bool _canRemoveOutputDevices = false;
+        public bool CanRemoveOutputDevices
+        {
+            get => _canRemoveOutputDevices;
+            set
+            {
+                if (value != _canRemoveOutputDevices)
+                {
+                    _canRemoveOutputDevices = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public EditOutputProfileViewModel()
+        {
+            _model = new OutputProfile();
+            CanRemoveOutputDevices = Model.OutputSettings.Count > 1;
+            SetBindings();
+        }
+
+        /// <summary>
+        ///  Edit a (copy of an) existing SoundClip in this EditSoundClip window. Save to overwrite original with copy
+        /// </summary>
+        /// <param name="model"></param>
+        public EditOutputProfileViewModel(OutputProfile model)
+        {
+            _model = model.ShallowCopy();
+            CanRemoveOutputDevices = Model.OutputSettings.Count > 1;
+            SetBindings();
+        }
+
+        private void SetBindings()
+        {
+            HasNameField = !string.IsNullOrEmpty(Model.Name);
+            Model.PropertyChanged += Model_PropertyChanged;
+            Model.OutputSettings.CollectionChanged += OutputSettings_CollectionChanged;
+        }
+
+        private void OutputSettings_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            CanRemoveOutputDevices = Model.OutputSettings.Count > 1;
+        }
+
+        /// <summary>
+        /// Update ViewModel properties when underlying model changes detected
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void Model_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(Model.Name))
+            {
+                HasNameField = !string.IsNullOrEmpty(Model.Name);
+            }
+        }
+
+        public void DeleteOutputProfile()
+        {
+            App.OutputProfileManager.RemoveOutputProfile(Model.Id);
+        }
+
+        public void SaveOutputProfile()
+        {
+            OutputProfile toSave = Model.ShallowCopy();
+            App.OutputProfileManager.SaveOutputProfile(toSave);
+            // Copy back and forth to incorporate validations done during saving
+            _model = toSave.ShallowCopy();
+            OnPropertyChanged(nameof(Model));
+        }
+
+        public void RemoveOutputDevice()
+        {
+            if (Model.OutputSettings.Count > 0)
+            {
+                Model.OutputSettings.RemoveAt(Model.OutputSettings.Count - 1);
+            }
+        }
+
+        public void AddOutputDevice()
+        {
+            Model.OutputSettings.Add(new OutputSettings());
+        }
+
+        public override void Dispose()
+        {
+            Model.PropertyChanged -= Model_PropertyChanged;
+            base.Dispose();
+        }
+    }
+}

--- a/ViewModels/EditSoundClipViewModel.cs
+++ b/ViewModels/EditSoundClipViewModel.cs
@@ -217,7 +217,7 @@ namespace Amplitude.ViewModels
 
         public void NewOutputProfile()
         {
-            Model.OutputProfileId = WindowManager.OpenEditOutputProfileWindow(null);
+            WindowManager.OpenEditOutputProfileWindow(null);
             OnPropertyChanged(nameof(OutputProfilesList));
             
         }

--- a/ViewModels/EditSoundClipViewModel.cs
+++ b/ViewModels/EditSoundClipViewModel.cs
@@ -133,7 +133,7 @@ namespace Amplitude.ViewModels
         /// <param name="model"></param>
         public EditSoundClipViewModel(SoundClip model)
         {
-            _model = model.CreateCopy();
+            _model = model.ShallowCopy();
             CanRemoveOutputDevices = Model.OutputSettingsFromProfile.Count > 1;
             SetBindings();
         }
@@ -196,6 +196,33 @@ namespace Amplitude.ViewModels
             //}
         }
 
+        public void IncreaseVolumeSmall()
+        {
+            if (Model.Volume < 100)
+            {
+                Model.Volume += 1;
+            }
+        }
+        public void DecreaseVolumeSmall()
+        {
+            if (Model.Volume > 0)
+            {
+                Model.Volume -= 1;
+            }
+        }
+
+        public void NewOutputProfile()
+        {
+            Model.OutputProfileId = WindowManager.OpenEditOutputProfileWindow(null);
+            OnPropertyChanged(nameof(OutputProfilesList));
+            
+        }
+
+        public void EditOutputProfile()
+        {
+            WindowManager.OpenEditOutputProfileWindow(Model.OutputProfileId);
+        }
+
         public void PlaySound()
         {
             Model.PlayAudio();
@@ -229,10 +256,10 @@ namespace Amplitude.ViewModels
 
         public void SaveClip()
         {
-            SoundClip toSave = Model.CreateCopy();
+            SoundClip toSave = Model.ShallowCopy();
             App.SoundClipManager.SaveClip(toSave);
             // Copy back and forth to delay ID update until fully saved
-            _model = toSave.CreateCopy();
+            _model = toSave.ShallowCopy();
             OnPropertyChanged(nameof(Model));
 
             if (addToGridCell != null && addToGridCell.Value.row >= 0 && addToGridCell.Value.col >= 0 &&

--- a/ViewModels/ErrorListViewModel.cs
+++ b/ViewModels/ErrorListViewModel.cs
@@ -38,26 +38,14 @@ namespace Amplitude.ViewModels
             Errors.Add(error);
         }
 
-        public void AddErrorSoundClip(SoundClip clip, ErrorType errorType, string? additionalData = null)
+        public void AddErrorOutputProfile(OutputProfile profile, OutputProfileErrorType errorType, string? additionalData = null)
         {
             string errorString = "";
 
             switch (errorType)
             {
-                case ErrorType.BAD_IMAGE_FORMAT:
-                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileBadFormatString"], clip.ImageFilePath));
-                    break;
-                case ErrorType.BAD_AUDIO_FORMAT:
-                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileBadFormatString"], clip.AudioFilePath));
-                    break;
-                case ErrorType.MISSING_IMAGE_FILE:
-                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileMissingString"], clip.ImageFilePath));
-                    break;
-                case ErrorType.MISSING_AUDIO_FILE:
-                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileMissingString"], clip.AudioFilePath));
-                    break;
-                case ErrorType.MISSING_DEVICE:
-                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["MissingDeviceString"], additionalData ?? ""));
+                case OutputProfileErrorType.MISSING_DEVICE:
+                    errorString = string.Format(Localization.Localizer.Instance["OutputProfileError"], profile.Name, string.Format(Localization.Localizer.Instance["MissingDeviceString"], additionalData ?? ""));
                     break;
             }
 
@@ -72,17 +60,61 @@ namespace Amplitude.ViewModels
                 }
             }
 
-            ErrorContainer error = new ErrorContainer(errorString, clip.Id);
+            ErrorContainer error = new ErrorContainer(errorString, profile);
 
             Errors.Add(error);
         }
 
-        public enum ErrorType
+        public void AddErrorSoundClip(SoundClip clip, SoundClipErrorType errorType, string? additionalData = null)
+        {
+            string errorString = "";
+
+            switch (errorType)
+            {
+                case SoundClipErrorType.BAD_IMAGE_FORMAT:
+                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileBadFormatString"], clip.ImageFilePath));
+                    break;
+                case SoundClipErrorType.BAD_AUDIO_FORMAT:
+                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileBadFormatString"], clip.AudioFilePath));
+                    break;
+                case SoundClipErrorType.MISSING_IMAGE_FILE:
+                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileMissingString"], clip.ImageFilePath));
+                    break;
+                case SoundClipErrorType.MISSING_AUDIO_FILE:
+                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["FileMissingString"], clip.AudioFilePath));
+                    break;
+                case SoundClipErrorType.MISSING_OUTPUT_PROFILE:
+                    errorString = string.Format(Localization.Localizer.Instance["SoundClipError"], clip.Name, string.Format(Localization.Localizer.Instance["MissingOutputProfileString"], additionalData ?? ""));
+                    break;
+            }
+
+            string[] lines = errorString.Split('\n');
+
+            if (lines.Length > 1)
+            {
+                errorString = "";
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    errorString += (i < lines.Length - 1) ? lines[i] + Environment.NewLine : lines[i];
+                }
+            }
+
+            ErrorContainer error = new ErrorContainer(errorString, clip);
+
+            Errors.Add(error);
+        }
+
+        public enum SoundClipErrorType
         {
             MISSING_IMAGE_FILE,
             MISSING_AUDIO_FILE,
             BAD_AUDIO_FORMAT,
             BAD_IMAGE_FORMAT,
+            MISSING_OUTPUT_PROFILE,
+        }
+
+        public enum OutputProfileErrorType
+        {
             MISSING_DEVICE,
         }
 

--- a/ViewModels/ViewModelBase.cs
+++ b/ViewModels/ViewModelBase.cs
@@ -34,6 +34,7 @@ namespace Amplitude.ViewModels
         protected ThemeHandler ThemeHandler { get => App.ThemeHandler; }
         protected SoundClipManager SoundClipManager { get => App.SoundClipManager; }
         protected OptionsManager OptionsManager { get => App.OptionsManager; }
+        protected OutputProfileManager OutputProfileManager { get => App.OutputProfileManager; }
         protected WindowManager WindowManager { get => App.WindowManager; }
         protected HotkeysManager HotkeysManager { get => App.HotkeysManager; }
         protected ISoundEngine SoundEngine { get => App.SoundEngine; }

--- a/Views/EditOutputProfile.axaml
+++ b/Views/EditOutputProfile.axaml
@@ -58,7 +58,8 @@
       </ExperimentalAcrylicBorder>
 
       <TextBlock IsVisible="{Binding CanUseCustomTitlebar}" Text="{i18n:Localize EditOutputProfileTitle}" Classes="TITLE" FontFamily="{Binding ThemeHandler.TitleFont}" FontWeight="Bold" Margin="10,10,10,10" HorizontalAlignment="Center" IsHitTestVisible="False" ></TextBlock>
-
+      <TextBlock x:Name="txt_blk_OutputProfileId" Text="{Binding Model.Id}" IsVisible="false"></TextBlock>
+      
       <!--<ScrollViewer Margin="0,30,0,0">-->
         <Grid Margin="0,30,0,0">
           <Grid.RowDefinitions>
@@ -150,7 +151,7 @@
 
           <Grid Grid.Row="2"  ColumnDefinitions="*,Auto">
             <StackPanel Orientation="Horizontal" Grid.Column="1">
-              <Button x:Name="btn_removeOutputProfile" Command="{Binding DeleteOutputProfile}" ToolTip.Tip="{i18n:Localize DeleteSoundClipButton}" Cursor="Hand" IsEnabled="{Binding Model.Id, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="5,5,10,5" HorizontalAlignment="Left">
+              <Button x:Name="btn_RemoveOutputProfile" Command="{Binding DeleteOutputProfile}" ToolTip.Tip="{i18n:Localize DeleteSoundClipButton}" Cursor="Hand" IsEnabled="{Binding Model.Id, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="5,5,10,5" HorizontalAlignment="Left">
                 <Panel>
                   <Image Source="{Binding ThemeHandler.Delete}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </Panel>

--- a/Views/EditOutputProfile.axaml
+++ b/Views/EditOutputProfile.axaml
@@ -1,0 +1,169 @@
+<!--
+    AmplitudeSoundboard
+    Copyright (C) 2021-2022 dan0v
+    https://git.dan0v.com/AmplitudeSoundboard
+
+    This file is part of AmplitudeSoundboard.
+
+    AmplitudeSoundboard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    AmplitudeSoundboard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:Amplitude.ViewModels"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="635"
+        xmlns:i18n="clr-namespace:Amplitude.Localization"
+        x:Class="Amplitude.Views.EditOutputProfile"
+        Icon="/Assets/Icon.ico"
+        Title="{i18n:Localize EditOutputProfileTitle}"
+        Width="400" Height="635" MinWidth="400" MinHeight="500"
+        TransparencyLevelHint="AcrylicBlur"
+        Background="Transparent"
+        ExtendClientAreaToDecorationsHint="{Binding CanUseCustomTitlebar}">
+
+    <Window.Styles>
+      <Style Selector="Image:disabled">
+        <Setter Property="Opacity" Value="0.5"/>
+      </Style>
+      <Style Selector="TextBlock">
+        <Setter Property="FontFamily" Value="{Binding ThemeHandler.BodyFont}"/>
+      </Style>
+      <Style Selector="TextBox">
+        <Setter Property="FontFamily" Value="{Binding ThemeHandler.BodyFont}"/>
+      </Style>
+      <Style Selector="Button">
+        <Setter Property="FontFamily" Value="{Binding ThemeHandler.BodyFont}"/>
+      </Style>
+    </Window.Styles>
+  
+    <Design.DataContext>
+        <vm:EditSoundClipViewModel/>
+    </Design.DataContext>
+  
+    <Panel>
+      
+      <ExperimentalAcrylicBorder IsHitTestVisible="False" Material="{Binding ThemeHandler.Acrylic}">
+      </ExperimentalAcrylicBorder>
+
+      <TextBlock IsVisible="{Binding CanUseCustomTitlebar}" Text="{i18n:Localize EditOutputProfileTitle}" Classes="TITLE" FontFamily="{Binding ThemeHandler.TitleFont}" FontWeight="Bold" Margin="10,10,10,10" HorizontalAlignment="Center" IsHitTestVisible="False" ></TextBlock>
+
+      <!--<ScrollViewer Margin="0,30,0,0">-->
+        <Grid Margin="0,30,0,0">
+          <Grid.RowDefinitions>
+            <RowDefinition Height="90"/>
+            <RowDefinition Height="*" MinHeight="60"/>
+            <RowDefinition Height="50"/>
+          </Grid.RowDefinitions>
+          
+          <!--Name-->
+          <Border Grid.Row="0" BorderThickness="2" CornerRadius="5" Margin="5" Padding="5">
+            <Border.BorderBrush>
+              <SolidColorBrush Color="{Binding ThemeHandler.BorderColor}"/>
+            </Border.BorderBrush>
+            <StackPanel>
+              <Label Content="{i18n:Localize OutputProfileNameLabel}" HorizontalAlignment="Center" Height="30"></Label>
+              <TextBox Text="{Binding Model.Name}" Watermark="{i18n:Localize ClipNamePlaceholder}" ToolTip.Tip="{Binding Model.Name}"></TextBox>
+            </StackPanel>
+          </Border>
+
+          <!--Output devices-->
+            <Border Grid.Row="1" Padding="5,0,5,0" Margin="5" BorderThickness="2" CornerRadius="5">
+              <Border.BorderBrush>
+                <SolidColorBrush Color="{Binding ThemeHandler.BorderColor}"/>
+              </Border.BorderBrush>
+                <Grid RowDefinitions="*,50">
+                  <ScrollViewer Grid.Row="0">
+                    <ItemsControl Items="{Binding Model.OutputSettings}">
+                      <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                          <Border BorderThickness="2" CornerRadius="5" Margin="5,5,5,0" Padding="5" Height="60">
+                            <Border.BorderBrush>
+                              <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.BorderColor}"/>
+                            </Border.BorderBrush>
+                            <Grid RowDefinitions="Auto,20,20">
+
+                              <Grid Grid.Row="2" Margin="0,-20,0,0">
+                                <Grid.ColumnDefinitions>
+                                  <ColumnDefinition Width="Auto"/>
+                                  <ColumnDefinition Width="*"/>
+                                  <ColumnDefinition Width="Auto"/>
+                                  <ColumnDefinition Width="150"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Grid.Column="0" Margin="5,0,5,0" Cursor="Hand" Command="{Binding DecreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                  <Panel>
+                                    <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowLeft}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                  </Panel>
+                                </Button>
+                                <Grid Grid.Column="1" RowDefinitions="*,20">
+                                  <StackPanel HorizontalAlignment="Center" Grid.Row="0" Orientation="Horizontal">
+                                    <Label Content="{i18n:Localize VolumeLabel}"></Label>
+                                    <Label Content="{Binding Volume}" HorizontalAlignment="Center"></Label>
+                                  </StackPanel>
+                                  <Slider Grid.Row="1" VerticalAlignment="Center" Height="50" Margin="0,-10,0,0" Cursor="Hand" SmallChange="1" LargeChange="10" TickFrequency="1" Orientation="Horizontal" Minimum="0" Maximum="100" IsSnapToTickEnabled="True" TickPlacement="None" Value="{Binding Path=Volume, Mode=TwoWay}" Padding="5,0,5,0">
+                                    <Slider.Foreground>
+                                      <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderForeground}"/>
+                                    </Slider.Foreground>
+                                    <Slider.Background>
+                                      <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderBackground}"/>
+                                    </Slider.Background>
+                                  </Slider>
+                                </Grid>
+                                <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding IncreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                  <Panel>
+                                    <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowRight}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                  </Panel>
+                                </Button>
+                                <ComboBox Width="150" Grid.Column="3" AutoScrollToSelectedItem="True" Margin="0,5,0,5" SelectedItem="{Binding DeviceName}" Items="{Binding DeviceList}" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
+                              </Grid>
+                            </Grid>
+                          </Border>
+                        </DataTemplate>
+                      </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                  </ScrollViewer>
+                  <Grid Grid.Row="1" ColumnDefinitions="*,*">
+                    <Button Cursor="Hand" IsEnabled="{Binding CanRemoveOutputDevices}" Grid.Column="0" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize RemoveSoundClipOutput}" Command="{Binding RemoveOutputDevice}">
+                      <Panel>
+                        <Image Source="{Binding ThemeHandler.Minus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Panel>
+                    </Button>
+                    <Button Cursor="Hand" Grid.Column="1" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize AddSoundClipOutput}" Command="{Binding AddOutputDevice}">
+                      <Panel>
+                        <Image Source="{Binding ThemeHandler.Plus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Panel>
+                    </Button>
+                  </Grid>
+                </Grid>
+          </Border>
+
+          <Grid Grid.Row="2"  ColumnDefinitions="*,Auto">
+            <StackPanel Orientation="Horizontal" Grid.Column="1">
+              <Button Command="{Binding DeleteOutputProfile}" ToolTip.Tip="{i18n:Localize DeleteSoundClipButton}" Cursor="Hand" IsEnabled="{Binding Model.Id, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="5,5,10,5" HorizontalAlignment="Left">
+                <Panel>
+                  <Image Source="{Binding ThemeHandler.Delete}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                </Panel>
+              </Button>
+              <Button ToolTip.Tip="{i18n:Localize SaveButton}" Cursor="Hand" Command="{Binding SaveOutputProfile}" Margin="5,5,10,5" HorizontalAlignment="Right">
+                <Panel>
+                  <Image Source="{Binding ThemeHandler.Save}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                </Panel>
+              </Button>
+            </StackPanel>
+          </Grid>
+
+        </Grid>
+    </Panel>
+  
+</Window>

--- a/Views/EditOutputProfile.axaml
+++ b/Views/EditOutputProfile.axaml
@@ -150,12 +150,12 @@
 
           <Grid Grid.Row="2"  ColumnDefinitions="*,Auto">
             <StackPanel Orientation="Horizontal" Grid.Column="1">
-              <Button Command="{Binding DeleteOutputProfile}" ToolTip.Tip="{i18n:Localize DeleteSoundClipButton}" Cursor="Hand" IsEnabled="{Binding Model.Id, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="5,5,10,5" HorizontalAlignment="Left">
+              <Button x:Name="btn_removeOutputProfile" Command="{Binding DeleteOutputProfile}" ToolTip.Tip="{i18n:Localize DeleteSoundClipButton}" Cursor="Hand" IsEnabled="{Binding Model.Id, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" Margin="5,5,10,5" HorizontalAlignment="Left">
                 <Panel>
                   <Image Source="{Binding ThemeHandler.Delete}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </Panel>
               </Button>
-              <Button ToolTip.Tip="{i18n:Localize SaveButton}" Cursor="Hand" Command="{Binding SaveOutputProfile}" Margin="5,5,10,5" HorizontalAlignment="Right">
+              <Button ToolTip.Tip="{i18n:Localize SaveButton}" Cursor="Hand" Command="{Binding SaveOutputProfile}" IsEnabled="{Binding HasNameField}" Margin="5,5,10,5" HorizontalAlignment="Right">
                 <Panel>
                   <Image Source="{Binding ThemeHandler.Save}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </Panel>

--- a/Views/EditOutputProfile.axaml.cs
+++ b/Views/EditOutputProfile.axaml.cs
@@ -29,6 +29,8 @@ namespace Amplitude.Views
 {
     public partial class EditOutputProfile : Window
     {
+        Button btn_removeOutputProfile;
+
         public EditOutputProfile()
         {
             InitializeComponent();
@@ -38,6 +40,14 @@ namespace Amplitude.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+
+            btn_removeOutputProfile = this.Find<Button>("btn_removeOutputProfile");
+            btn_removeOutputProfile.Click += Btn_removeOutputProfile_Click;
+        }
+
+        private void Btn_removeOutputProfile_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            this.Close();
         }
 
         protected override void OnClosing(CancelEventArgs e)

--- a/Views/EditOutputProfile.axaml.cs
+++ b/Views/EditOutputProfile.axaml.cs
@@ -1,0 +1,50 @@
+/*
+    AmplitudeSoundboard
+    Copyright (C) 2021-2022 dan0v
+    https://git.dan0v.com/AmplitudeSoundboard
+
+    This file is part of AmplitudeSoundboard.
+
+    AmplitudeSoundboard is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    AmplitudeSoundboard is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with AmplitudeSoundboard.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+using Amplitude.ViewModels;
+using AmplitudeSoundboard;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using System.ComponentModel;
+
+namespace Amplitude.Views
+{
+    public partial class EditOutputProfile : Window
+    {
+        public EditOutputProfile()
+        {
+            InitializeComponent();
+
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            App.WindowManager.ClosedEditOutputProfileWindow(((EditOutputProfileViewModel)this.DataContext).Model.Id);
+            ((EditOutputProfileViewModel)DataContext).Dispose();
+            base.OnClosing(e);
+        }
+    }
+}

--- a/Views/EditOutputProfile.axaml.cs
+++ b/Views/EditOutputProfile.axaml.cs
@@ -21,6 +21,7 @@
 
 using Amplitude.ViewModels;
 using AmplitudeSoundboard;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using System.ComponentModel;
@@ -29,7 +30,8 @@ namespace Amplitude.Views
 {
     public partial class EditOutputProfile : Window
     {
-        Button btn_removeOutputProfile;
+        Button btn_RemoveOutputProfile;
+        TextBlock txt_blk_OutputProfileId;
 
         public EditOutputProfile()
         {
@@ -41,13 +43,27 @@ namespace Amplitude.Views
         {
             AvaloniaXamlLoader.Load(this);
 
-            btn_removeOutputProfile = this.Find<Button>("btn_removeOutputProfile");
-            btn_removeOutputProfile.Click += Btn_removeOutputProfile_Click;
+            txt_blk_OutputProfileId = this.FindControl<TextBlock>("txt_blk_OutputProfileId");
+            txt_blk_OutputProfileId.PropertyChanged += Txt_blk_OutputProfileId_PropertyChanged;
+
+            btn_RemoveOutputProfile = this.Find<Button>("btn_RemoveOutputProfile");
+            btn_RemoveOutputProfile.Click += Btn_RemoveOutputProfile_Click;
         }
 
-        private void Btn_removeOutputProfile_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private void Btn_RemoveOutputProfile_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         {
             this.Close();
+        }
+
+        private void Txt_blk_OutputProfileId_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property == TextBlock.TextProperty)
+            {
+                if (!string.IsNullOrEmpty((string)e.NewValue) && e.NewValue != e.OldValue)
+                {
+                    App.WindowManager.OpenedEditOutputProfileWindow(((EditOutputProfileViewModel)this.DataContext).Model.Id, this);
+                }
+            }
         }
 
         protected override void OnClosing(CancelEventArgs e)

--- a/Views/EditSoundClip.axaml
+++ b/Views/EditSoundClip.axaml
@@ -58,8 +58,8 @@
       </ExperimentalAcrylicBorder>
 
       <TextBlock IsVisible="{Binding CanUseCustomTitlebar}" Text="{i18n:Localize EditSoundClipTitle}" Classes="TITLE" FontFamily="{Binding ThemeHandler.TitleFont}" FontWeight="Bold" Margin="10,10,10,10" HorizontalAlignment="Center" IsHitTestVisible="False" ></TextBlock>
-
       <TextBlock x:Name="txt_blk_SoundClipId" Text="{Binding Model.Id}" IsVisible="false"></TextBlock>
+      
       <!--<ScrollViewer Margin="0,30,0,0">-->
         <Grid Margin="0,30,0,0">
           <Grid.RowDefinitions>
@@ -98,7 +98,7 @@
                 <Label Content="{i18n:Localize OutputProfileLabel}" HorizontalAlignment="Center" Height="30" Margin="5,5,5,0"></Label>
 
                 <Grid ColumnDefinitions="*,Auto,Auto">
-                  <ComboBox x:Name="cb_outputProfileSelection" Grid.Column="0" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" AutoScrollToSelectedItem="True" Margin="5,0,5,0" SelectedItem="{Binding CurrentOutputProfile}" Items="{Binding OutputProfilesList}">
+                  <ComboBox x:Name="cb_OutputProfileSelection" Grid.Column="0" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" AutoScrollToSelectedItem="True" Margin="5,0,5,0" SelectedItem="{Binding CurrentOutputProfile}" Items="{Binding OutputProfilesList}">
                     <ComboBox.ItemTemplate>
                       <DataTemplate>
                         <TextBlock Text="{Binding Name}" />

--- a/Views/EditSoundClip.axaml
+++ b/Views/EditSoundClip.axaml
@@ -23,12 +23,12 @@
         xmlns:vm="using:Amplitude.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="635"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="605"
         xmlns:i18n="clr-namespace:Amplitude.Localization"
         x:Class="Amplitude.Views.EditSoundClip"
         Icon="/Assets/Icon.ico"
         Title="{i18n:Localize EditSoundClipTitle}"
-        Width="400" Height="635" MinWidth="400" MinHeight="500"
+        Width="400" Height="605" MinWidth="400" MinHeight="500"
         TransparencyLevelHint="AcrylicBlur"
         Background="Transparent"
         ExtendClientAreaToDecorationsHint="{Binding CanUseCustomTitlebar}">
@@ -64,7 +64,7 @@
         <Grid Margin="0,30,0,0">
           <Grid.RowDefinitions>
             <RowDefinition Height="120"/>
-            <RowDefinition Height="*" MinHeight="60"/>
+            <RowDefinition Height="135"/>
             <RowDefinition Height="90"/>
             <RowDefinition Height="90"/>
             <RowDefinition Height="90"/>
@@ -78,7 +78,7 @@
             </Border.BorderBrush>
             <StackPanel>
               <Label Content="{i18n:Localize ClipNameLabel}" HorizontalAlignment="Center" Height="30"></Label>
-              <TextBox Text="{Binding Model.Name}" Watermark="{i18n:Localize ClipNamePlaceholder}" ToolTip.Tip="{Binding Model.Name}"></TextBox>
+              <TextBox Text="{Binding Model.Name}" Watermark="{i18n:Localize ClipNamePlaceholder}" ToolTip.Tip="{Binding Model.Name}" Margin="5,0,5,0"></TextBox>
 
               <!--Show name in grid tile toggle-->
               <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Center">
@@ -95,70 +95,52 @@
               </Border.BorderBrush>
 
               <StackPanel>
-                <ComboBox AutoScrollToSelectedItem="True" Margin="0,5,0,5" SelectedItem="{Binding Model.OutputProfileId}" Items="{Binding OutputProfilesList}" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
-                
-                <Grid RowDefinitions="*,50">
-                  <ScrollViewer Grid.Row="0">
-                    <ItemsControl Items="{Binding Model.OutputSettingsFromProfile}">
-                      <ItemsControl.ItemTemplate>
-                        <DataTemplate>
-                          <Border BorderThickness="2" CornerRadius="5" Margin="5,5,5,0" Padding="5" Height="60">
-                            <Border.BorderBrush>
-                              <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.BorderColor}"/>
-                            </Border.BorderBrush>
-                            <Grid RowDefinitions="Auto,20,20">
+                <Label Content="{i18n:Localize OutputProfileLabel}" HorizontalAlignment="Center" Height="30" Margin="5,5,5,0"></Label>
 
-                              <Grid Grid.Row="2" Margin="0,-20,0,0">
-                                <Grid.ColumnDefinitions>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="*"/>
-                                  <ColumnDefinition Width="Auto"/>
-                                  <ColumnDefinition Width="150"/>
-                                </Grid.ColumnDefinitions>
-                                <Button Grid.Column="0" Margin="5,0,5,0" Cursor="Hand" Command="{Binding DecreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                  <Panel>
-                                    <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowLeft}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                  </Panel>
-                                </Button>
-                                <Grid Grid.Column="1" RowDefinitions="*,20">
-                                  <StackPanel HorizontalAlignment="Center" Grid.Row="0" Orientation="Horizontal">
-                                    <Label Content="{i18n:Localize VolumeLabel}"></Label>
-                                    <Label Content="{Binding Volume}" HorizontalAlignment="Center"></Label>
-                                  </StackPanel>
-                                  <Slider Grid.Row="1" VerticalAlignment="Center" Height="50" Margin="0,-10,0,0" Cursor="Hand" SmallChange="1" LargeChange="10" TickFrequency="1" Orientation="Horizontal" Minimum="0" Maximum="100" IsSnapToTickEnabled="True" TickPlacement="None" Value="{Binding Path=Volume, Mode=TwoWay}" Padding="5,0,5,0">
-                                    <Slider.Foreground>
-                                      <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderForeground}"/>
-                                    </Slider.Foreground>
-                                    <Slider.Background>
-                                      <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderBackground}"/>
-                                    </Slider.Background>
-                                  </Slider>
-                                </Grid>
-                                <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding IncreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                  <Panel>
-                                    <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowRight}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                  </Panel>
-                                </Button>
-                                <ComboBox Width="150" Grid.Column="3" AutoScrollToSelectedItem="True" Margin="0,5,0,5" SelectedItem="{Binding DeviceName}" Items="{Binding DeviceList}" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
-                              </Grid>
-                            </Grid>
-                          </Border>
-                        </DataTemplate>
-                      </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                  </ScrollViewer>
-                  <Grid Grid.Row="1" ColumnDefinitions="*,*">
-                    <Button Cursor="Hand" IsEnabled="{Binding CanRemoveOutputDevices}" Grid.Column="0" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize RemoveSoundClipOutput}" Command="{Binding RemoveOutputDevice}">
-                      <Panel>
-                        <Image Source="{Binding ThemeHandler.Minus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                      </Panel>
-                    </Button>
-                    <Button Cursor="Hand" Grid.Column="1" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize AddSoundClipOutput}" Command="{Binding AddOutputDevice}">
-                      <Panel>
-                        <Image Source="{Binding ThemeHandler.Plus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                      </Panel>
-                    </Button>
+                <Grid ColumnDefinitions="*,Auto,Auto">
+                  <ComboBox Grid.Column="0" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" AutoScrollToSelectedItem="True" Margin="5,0,5,0" SelectedItem="{Binding Model.OutputProfileId}" Items="{Binding OutputProfilesList}" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
+                  <Button Grid.Column="1" Margin="5,0,5,0" Cursor="Hand" Command="{Binding EditOutputProfile}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Panel>
+                      <Image Source="{Binding ThemeHandler.Settings}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                    </Panel>
+                  </Button>
+                  <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding NewOutputProfile}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Panel>
+                      <Image Source="{Binding ThemeHandler.Settings}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                    </Panel>
+                  </Button>
+                </Grid>
+
+                <Grid Grid.Row="2" Margin="0,5,0,5">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                  </Grid.ColumnDefinitions>
+                  <Button Grid.Column="0" Margin="5,0,5,0" Cursor="Hand" Command="{Binding DecreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Panel>
+                      <Image Source="{Binding ThemeHandler.ArrowLeft}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                    </Panel>
+                  </Button>
+                  <Grid Grid.Column="1" RowDefinitions="*,20">
+                    <StackPanel HorizontalAlignment="Center" Grid.Row="0" Orientation="Horizontal">
+                      <Label Content="{i18n:Localize VolumeLabel}"></Label>
+                      <Label Content="{Binding Model.Volume}" HorizontalAlignment="Center"></Label>
+                    </StackPanel>
+                    <Slider Grid.Row="1" VerticalAlignment="Center" Height="50" Margin="0,-10,0,0" Cursor="Hand" SmallChange="1" LargeChange="10" TickFrequency="1" Orientation="Horizontal" Minimum="0" Maximum="100" IsSnapToTickEnabled="True" TickPlacement="None" Value="{Binding Path=Model.Volume, Mode=TwoWay}" Padding="5,0,5,0">
+                      <Slider.Foreground>
+                        <SolidColorBrush Color="{Binding ThemeHandler.SliderForeground}"/>
+                      </Slider.Foreground>
+                      <Slider.Background>
+                        <SolidColorBrush Color="{Binding ThemeHandler.SliderBackground}"/>
+                      </Slider.Background>
+                    </Slider>
                   </Grid>
+                  <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding IncreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                    <Panel>
+                      <Image Source="{Binding ThemeHandler.ArrowRight}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                    </Panel>
+                  </Button>
                 </Grid>
               </StackPanel>
           </Border>

--- a/Views/EditSoundClip.axaml
+++ b/Views/EditSoundClip.axaml
@@ -94,70 +94,73 @@
                 <SolidColorBrush Color="{Binding ThemeHandler.BorderColor}"/>
               </Border.BorderBrush>
 
-              <Grid RowDefinitions="*,50">
+              <StackPanel>
+                <ComboBox AutoScrollToSelectedItem="True" Margin="0,5,0,5" SelectedItem="{Binding Model.OutputProfileId}" Items="{Binding OutputProfilesList}" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
                 
-                <ScrollViewer Grid.Row="0">
-                  <ItemsControl Items="{Binding Model.OutputSettings}">
-                    <ItemsControl.ItemTemplate>
-                      <DataTemplate>
-                        <Border BorderThickness="2" CornerRadius="5" Margin="5,5,5,0" Padding="5" Height="60">
-                          <Border.BorderBrush>
-                            <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.BorderColor}"/>
-                          </Border.BorderBrush>
-                          <Grid RowDefinitions="Auto,20,20">
-                            
-                            <Grid Grid.Row="2" Margin="0,-20,0,0">
-                              <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                                <ColumnDefinition Width="150"/>
-                              </Grid.ColumnDefinitions>
-                              <Button Grid.Column="0" Margin="5,0,5,0" Cursor="Hand" Command="{Binding DecreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <Panel>
-                                  <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowLeft}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                </Panel>
-                              </Button>
-                              <Grid Grid.Column="1" RowDefinitions="*,20">
-                                <StackPanel HorizontalAlignment="Center" Grid.Row="0" Orientation="Horizontal">
-                                  <Label Content="{i18n:Localize VolumeLabel}"></Label>
-                                  <Label Content="{Binding Volume}" HorizontalAlignment="Center"></Label>
-                                </StackPanel>
-                                <Slider Grid.Row="1" VerticalAlignment="Center" Height="50" Margin="0,-10,0,0" Cursor="Hand" SmallChange="1" LargeChange="10" TickFrequency="1" Orientation="Horizontal" Minimum="0" Maximum="100" IsSnapToTickEnabled="True" TickPlacement="None" Value="{Binding Path=Volume, Mode=TwoWay}" Padding="5,0,5,0">
-                                  <Slider.Foreground>
-                                    <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderForeground}"/>
-                                  </Slider.Foreground>
-                                  <Slider.Background>
-                                    <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderBackground}"/>
-                                  </Slider.Background>
-                                </Slider>
+                <Grid RowDefinitions="*,50">
+                  <ScrollViewer Grid.Row="0">
+                    <ItemsControl Items="{Binding Model.OutputSettingsFromProfile}">
+                      <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                          <Border BorderThickness="2" CornerRadius="5" Margin="5,5,5,0" Padding="5" Height="60">
+                            <Border.BorderBrush>
+                              <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.BorderColor}"/>
+                            </Border.BorderBrush>
+                            <Grid RowDefinitions="Auto,20,20">
+
+                              <Grid Grid.Row="2" Margin="0,-20,0,0">
+                                <Grid.ColumnDefinitions>
+                                  <ColumnDefinition Width="Auto"/>
+                                  <ColumnDefinition Width="*"/>
+                                  <ColumnDefinition Width="Auto"/>
+                                  <ColumnDefinition Width="150"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Grid.Column="0" Margin="5,0,5,0" Cursor="Hand" Command="{Binding DecreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                  <Panel>
+                                    <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowLeft}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                  </Panel>
+                                </Button>
+                                <Grid Grid.Column="1" RowDefinitions="*,20">
+                                  <StackPanel HorizontalAlignment="Center" Grid.Row="0" Orientation="Horizontal">
+                                    <Label Content="{i18n:Localize VolumeLabel}"></Label>
+                                    <Label Content="{Binding Volume}" HorizontalAlignment="Center"></Label>
+                                  </StackPanel>
+                                  <Slider Grid.Row="1" VerticalAlignment="Center" Height="50" Margin="0,-10,0,0" Cursor="Hand" SmallChange="1" LargeChange="10" TickFrequency="1" Orientation="Horizontal" Minimum="0" Maximum="100" IsSnapToTickEnabled="True" TickPlacement="None" Value="{Binding Path=Volume, Mode=TwoWay}" Padding="5,0,5,0">
+                                    <Slider.Foreground>
+                                      <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderForeground}"/>
+                                    </Slider.Foreground>
+                                    <Slider.Background>
+                                      <SolidColorBrush Color="{Binding $parent[ItemsControl].DataContext.ThemeHandler.SliderBackground}"/>
+                                    </Slider.Background>
+                                  </Slider>
+                                </Grid>
+                                <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding IncreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                  <Panel>
+                                    <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowRight}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                                  </Panel>
+                                </Button>
+                                <ComboBox Width="150" Grid.Column="3" AutoScrollToSelectedItem="True" Margin="0,5,0,5" SelectedItem="{Binding DeviceName}" Items="{Binding DeviceList}" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
                               </Grid>
-                              <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding IncreaseVolumeSmall}" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                <Panel>
-                                  <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.ArrowRight}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                </Panel>
-                              </Button>
-                              <ComboBox Width="150" Grid.Column="3" AutoScrollToSelectedItem="True" Margin="0,5,0,5" SelectedItem="{Binding DeviceName}" Items="{Binding DeviceList}" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
                             </Grid>
-                          </Grid>
-                        </Border>
-                      </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                  </ItemsControl>
-                </ScrollViewer>
-                <Grid Grid.Row="1" ColumnDefinitions="*,*">
-                  <Button Cursor="Hand" IsEnabled="{Binding CanRemoveOutputDevices}" Grid.Column="0" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize RemoveSoundClipOutput}" Command="{Binding RemoveOutputDevice}">
-                    <Panel>
-                      <Image Source="{Binding ThemeHandler.Minus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                    </Panel>
-                  </Button>
-                  <Button Cursor="Hand" Grid.Column="1" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize AddSoundClipOutput}" Command="{Binding AddOutputDevice}">
-                    <Panel>
-                      <Image Source="{Binding ThemeHandler.Plus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                    </Panel>
-                  </Button>
+                          </Border>
+                        </DataTemplate>
+                      </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                  </ScrollViewer>
+                  <Grid Grid.Row="1" ColumnDefinitions="*,*">
+                    <Button Cursor="Hand" IsEnabled="{Binding CanRemoveOutputDevices}" Grid.Column="0" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize RemoveSoundClipOutput}" Command="{Binding RemoveOutputDevice}">
+                      <Panel>
+                        <Image Source="{Binding ThemeHandler.Minus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Panel>
+                    </Button>
+                    <Button Cursor="Hand" Grid.Column="1" HorizontalAlignment="Center" ToolTip.Tip="{i18n:Localize AddSoundClipOutput}" Command="{Binding AddOutputDevice}">
+                      <Panel>
+                        <Image Source="{Binding ThemeHandler.Plus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Panel>
+                    </Button>
+                  </Grid>
                 </Grid>
-            </Grid>
+              </StackPanel>
           </Border>
           
           <!--Audio File-->

--- a/Views/EditSoundClip.axaml
+++ b/Views/EditSoundClip.axaml
@@ -98,15 +98,22 @@
                 <Label Content="{i18n:Localize OutputProfileLabel}" HorizontalAlignment="Center" Height="30" Margin="5,5,5,0"></Label>
 
                 <Grid ColumnDefinitions="*,Auto,Auto">
-                  <ComboBox Grid.Column="0" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" AutoScrollToSelectedItem="True" Margin="5,0,5,0" SelectedItem="{Binding Model.OutputProfileId}" Items="{Binding OutputProfilesList}" ToolTip.Tip="{i18n:Localize OutputDeviceLabel}"></ComboBox>
-                  <Button Grid.Column="1" Margin="5,0,5,0" Cursor="Hand" Command="{Binding EditOutputProfile}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                  <ComboBox x:Name="cb_outputProfileSelection" Grid.Column="0" HorizontalContentAlignment="Stretch" HorizontalAlignment="Stretch" AutoScrollToSelectedItem="True" Margin="5,0,5,0" SelectedItem="{Binding CurrentOutputProfile}" Items="{Binding OutputProfilesList}">
+                    <ComboBox.ItemTemplate>
+                      <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                      </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                  </ComboBox>
+                  
+                  <Button Grid.Column="1" Margin="5,0,5,0" Cursor="Hand" Command="{Binding EditOutputProfile}" ToolTip.Tip="{i18n:Localize EditOutputProfileTooltip}" HorizontalAlignment="Center" VerticalAlignment="Center">
                     <Panel>
                       <Image Source="{Binding ThemeHandler.Settings}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
                     </Panel>
                   </Button>
-                  <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding NewOutputProfile}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                  <Button Grid.Column="2" Margin="5,0,5,0" Cursor="Hand" Command="{Binding NewOutputProfile}" ToolTip.Tip="{i18n:Localize NewOutputProfileTooltip}"  HorizontalAlignment="Center" VerticalAlignment="Center">
                     <Panel>
-                      <Image Source="{Binding ThemeHandler.Settings}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      <Image Source="{Binding ThemeHandler.Plus}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
                     </Panel>
                   </Button>
                 </Grid>

--- a/Views/EditSoundClip.axaml.cs
+++ b/Views/EditSoundClip.axaml.cs
@@ -35,6 +35,7 @@ namespace Amplitude.Views
     public partial class EditSoundClip : Window
     {
         private TextBlock txt_blk_SoundClipId;
+        private ComboBox cb_outputProfileSelection;
         private Button btn_BrowseAudioFilePath;
         private Button btn_BrowseImageFilePath;
         private Button btn_Delete;
@@ -54,8 +55,16 @@ namespace Amplitude.Views
             btn_Delete = this.FindControl<Button>("btn_Delete");
             btn_Delete.Click += DeleteSoundClip;
 
+            cb_outputProfileSelection = this.Find<ComboBox>("cb_outputProfileSelection");
+            cb_outputProfileSelection.SelectionChanged += cb_outputProfileSelectionChanged;
+
             EffectiveViewportChanged += EditSoundClip_EffectiveViewportChanged;
 
+        }
+
+        private void cb_outputProfileSelectionChanged(object? sender, SelectionChangedEventArgs e)
+        {
+            ((EditSoundClipViewModel)DataContext).OutputProfileSelectionChanged(sender, e);
         }
 
         private void EditSoundClip_EffectiveViewportChanged(object? sender, Avalonia.Layout.EffectiveViewportChangedEventArgs e)

--- a/Views/EditSoundClip.axaml.cs
+++ b/Views/EditSoundClip.axaml.cs
@@ -35,7 +35,7 @@ namespace Amplitude.Views
     public partial class EditSoundClip : Window
     {
         private TextBlock txt_blk_SoundClipId;
-        private ComboBox cb_outputProfileSelection;
+        private ComboBox cb_OutputProfileSelection;
         private Button btn_BrowseAudioFilePath;
         private Button btn_BrowseImageFilePath;
         private Button btn_Delete;
@@ -55,14 +55,14 @@ namespace Amplitude.Views
             btn_Delete = this.FindControl<Button>("btn_Delete");
             btn_Delete.Click += DeleteSoundClip;
 
-            cb_outputProfileSelection = this.Find<ComboBox>("cb_outputProfileSelection");
-            cb_outputProfileSelection.SelectionChanged += cb_outputProfileSelectionChanged;
+            cb_OutputProfileSelection = this.Find<ComboBox>("cb_OutputProfileSelection");
+            cb_OutputProfileSelection.SelectionChanged += Cb_OutputProfileSelectionChanged;
 
             EffectiveViewportChanged += EditSoundClip_EffectiveViewportChanged;
 
         }
 
-        private void cb_outputProfileSelectionChanged(object? sender, SelectionChangedEventArgs e)
+        private void Cb_OutputProfileSelectionChanged(object? sender, SelectionChangedEventArgs e)
         {
             ((EditSoundClipViewModel)DataContext).OutputProfileSelectionChanged(sender, e);
         }

--- a/Views/ErrorList.axaml
+++ b/Views/ErrorList.axaml
@@ -76,6 +76,11 @@
                         <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.LaunchItem}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
                       </Panel>
                     </Button>
+                    <Button Margin="0,0,5,0" Grid.Column="1" Cursor="Hand" Command="{Binding OpenEditOutputProfileWindow}" HorizontalAlignment="Center" VerticalAlignment="Center" ToolTip.Tip="{i18n:Localize EditOutputProfileTooltip}" IsVisible="{Binding LinkedOutputProfile}">
+                      <Panel>
+                        <Image Source="{Binding $parent[ItemsControl].DataContext.ThemeHandler.LaunchItem}" Height="20" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                      </Panel>
+                    </Button>
                   </Grid>
                 </Border>
               </DataTemplate>

--- a/Views/GlobalSettings.axaml
+++ b/Views/GlobalSettings.axaml
@@ -23,13 +23,13 @@
         xmlns:vm="using:Amplitude.ViewModels"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="715"
+        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="620"
         xmlns:i18n="clr-namespace:Amplitude.Localization"
         xmlns:converters="clr-namespace:Amplitude.Converters"
         x:Class="Amplitude.Views.GlobalSettings"
         Icon="/Assets/Icon.ico"
         Title="{i18n:Localize GlobalSettingsTitle}"
-        Width="400" Height="715" MinWidth="400" MinHeight="320"
+        Width="400" Height="620" MinWidth="400" MinHeight="320"
         TransparencyLevelHint="AcrylicBlur"
         Background="Transparent"
         ExtendClientAreaToDecorationsHint="{Binding CanUseCustomTitlebar}">
@@ -97,6 +97,7 @@
           </Border>
 
           <!--Volume-->
+          <!--
           <Border BorderThickness="2" CornerRadius="5" Margin="5" Padding="5">
             <Border.BorderBrush>
               <SolidColorBrush Color="{Binding ThemeHandler.BorderColor}"/>
@@ -139,7 +140,8 @@
               </Grid>
             </Grid>
           </Border>
-
+          -->
+          
           <!--Grid size-->
           <Border BorderThickness="2" CornerRadius="5" Margin="5" Padding="5">
             <Border.BorderBrush>

--- a/Views/SoundBoardGridItem.axaml.cs
+++ b/Views/SoundBoardGridItem.axaml.cs
@@ -22,6 +22,7 @@
 using Amplitude.Models;
 using Amplitude.ViewModels;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 
 namespace Amplitude.Views
@@ -39,12 +40,20 @@ namespace Amplitude.Views
 
         private void Control_PointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e)
         {
-            if (!e.Handled && e.MouseButton == Avalonia.Input.MouseButton.Left)
+            if (!e.Handled && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
             {
                 SoundClip? Model = ((SoundBoardGridItemViewModel)DataContext)?.Model;
                 if (Model != null && !string.IsNullOrEmpty(Model.Id))
                 {
                     Model.PlayAudio();
+                }
+            }
+            else if (!e.Handled && e.GetCurrentPoint(this).Properties.IsMiddleButtonPressed)
+            {
+                SoundClip? Model = ((SoundBoardGridItemViewModel)DataContext)?.Model;
+                if (Model != null && !string.IsNullOrEmpty(Model.Id))
+                {
+                    Model.AddAudioToQueue();
                 }
             }
         }


### PR DESCRIPTION
Closes #42 by allowing output profiles to be specified on sound clips rather than setting all output settings over and over for every clip.

Existing configurations will be migrated to the new profiles system by grouping clips with the same output devices into a profile.