### PR TITLE
[Possible Feature] Allow All Previous Tracks to Stop Playing When a New One is Queued

### DIFF
--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -205,6 +205,12 @@ namespace Amplitude.Helpers
         public void Play(SoundClip source, bool fromQueue = false)
         {
             var tempId = source.Id ?? source.AudioFilePath;
+
+            if (App.ConfigManager.Config.StopPreviousAudioOnTrigger)
+            {
+                Reset();
+            }
+
             if (!fromQueue && App.ConfigManager.Config.StopAudioOnRepeatTrigger && ClipPlayingOrQueued(tempId))
             {
                 StopAndRemoveFromQueue(tempId);

--- a/Localization/Language.Designer.cs
+++ b/Localization/Language.Designer.cs
@@ -880,6 +880,15 @@ namespace Amplitude.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Stop previous audio from playing.
+        /// </summary>
+        internal static string StopPreviousAudioTrack {
+            get {
+                return ResourceManager.GetString("StopPreviousAudioTrack", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Test audio.
         /// </summary>
         internal static string TestSound {

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -399,6 +399,9 @@
   <data name="StopAudioOnRetrigger" xml:space="preserve">
     <value>Toggle audio when triggered repeatedly</value>
   </data>
+  <data name="StopPreviousAudioTrack" xml:space="preserve">
+	<value>Stop previous audio from playing</value>	
+  </data>
   <data name="AccentColorLabel" xml:space="preserve">
     <value>Accent color</value>
   </data>

--- a/Models/Config.cs
+++ b/Models/Config.cs
@@ -181,6 +181,20 @@ namespace Amplitude.Models
             }
         }
 
+        private bool _stopPreviousAudioOnTrigger = false;
+        public bool StopPreviousAudioOnTrigger
+        {
+            get => _stopPreviousAudioOnTrigger;
+            set
+            {
+                if(value != _stopPreviousAudioOnTrigger)
+                {
+                    _stopPreviousAudioOnTrigger = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
         public Config()
         {
             Language = Localizer.Instance.TryUseSystemLanguageFallbackEnglish();

--- a/Views/GlobalSettings.axaml
+++ b/Views/GlobalSettings.axaml
@@ -156,6 +156,17 @@
             </Grid>
           </Border>
 
+		      <!--Stop multiple tracks from playing-->
+		      <Border BorderThickness="2" CornerRadius="5" Margin="5" Padding="5">
+			      <Border.BorderBrush>
+		            <SolidColorBrush Color="{Binding ThemeManager.Theme.BorderColor}"/>
+			      </Border.BorderBrush>
+			      <Grid ColumnDefinitions="*,Auto" HorizontalAlignment="Center">
+				      <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="5,0,5,0" HorizontalAlignment="Center" TextTrimming="CharacterEllipsis"  Text="{i18n:Localize StopPreviousAudioTrack}" ></TextBlock>
+				      <CheckBox Grid.Column="1" HorizontalAlignment="Center" Margin="5,0,5,0" VerticalAlignment="Center" IsChecked="{Binding Model.StopPreviousAudioOnTrigger}" Cursor="Hand"/>
+			      </Grid>
+		      </Border>
+
           <!--Check for updates-->
           <Border BorderThickness="2" CornerRadius="5" Margin="5" Padding="5">
             <Border.BorderBrush>


### PR DESCRIPTION
Hey,

First of all, thank you very much for this software, it's by far the best & simple free soundboard out there. I've been using it quite a bit on my streams.

A problem I've had is where I want to only ever play one track at a time, so the previous ones would stop playing. `AmplitudeSoundboard` does currently let you stop the same track if triggered twice, but you can still queue up a longer audio that would play regardless when a separate track is queued. My use-case required stopping all of them before you queue up the new track.

This is the initial PR, I've basically just replicated the toggle audio feature and added a check to the `Play` function that will reset the queue if the relevant config is set.

If this desirable, let me know what text you would prefer on the localisation. 