### PR TITLE
feat: Adds a 1 second fade out to stopped channels

### DIFF
--- a/AmplitudeSoundboard.csproj
+++ b/AmplitudeSoundboard.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Localization\Language.Designer.cs">

--- a/Helpers/MSoundEngine.cs
+++ b/Helpers/MSoundEngine.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Timers;
 
 namespace Amplitude.Helpers
@@ -177,8 +178,14 @@ namespace Amplitude.Helpers
                 var toRemove = CurrentlyPlaying.Where(clip => clip.SoundClipId == id).ToList();
                 foreach (var clip in toRemove)
                 {
-                    Bass.StreamFree(clip.BassStreamId);
-                    CurrentlyPlaying.Remove(clip);
+                    Bass.ChannelSlideAttribute(clip.BassStreamId, ChannelAttribute.Volume, 0, 1000);
+                    var t = Task.Run(async delegate
+                    {
+                        await Task.Delay(1000);
+                        Bass.StreamFree(clip.BassStreamId);
+                        CurrentlyPlaying.Remove(clip);
+                    });
+                    t.Wait();
                 }
             }
         }
@@ -330,7 +337,14 @@ namespace Amplitude.Helpers
                 {
                     CurrentlyPlaying.Remove(track);
                 }
-                Bass.StreamFree(bassId);
+                
+                Bass.ChannelSlideAttribute(bassId, ChannelAttribute.Volume, 0, 1000);
+                var t = Task.Run(async delegate
+                {
+                    await Task.Delay(1000);
+                    Bass.StreamFree(bassId);
+                });
+                t.Wait();
             }
         }
 


### PR DESCRIPTION
This is just a proof of concept for using the built in [ChannelSlideAttribute method in BASS](https://www.un4seen.com/doc/#bass/BASS_ChannelSlideAttribute.html). I haven't dove too deeply into how Amplitude is structured for things like UI changes, so this is just a functional demo.

In #72, @dan0v, you said, "I would appreciate any PRs which can at least get features started." This is my attempt at that!

For this to be functional for a mainline release, I think the MVP would be:

- [ ] Enabling / disabling global fade out
- [ ] Setting length of fade out

And I think the best implementation would include:

- [ ] Enable / disable fade out per channel
- [ ] Enable / disable fade out when stopping all channels, vs just stopping one.