### PR TITLE
Add native macOS ARM64 build support

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -35,7 +35,8 @@ jobs:
         sudo apt-get install -y zip unzip libfuse2
         cd Publish/Windows && /usr/bin/bash ./Windows.sh
         cd ../Linux && /usr/bin/bash ./Appimage.sh
-        cd ../MacOS && /usr/bin/bash ./MacOS.sh
+        cd ../MacOS && /usr/bin/bash ./MacOS.sh osx-x64
+        /usr/bin/bash ./MacOS.sh osx-arm64
         echo "VERSION=$(cat ../version.txt | sed 's/ *$//g' | sed 's/\r//' | sed ':a;N;$!ba;s/\n//g')" >> "$GITHUB_ENV"
 
     - name: Release
@@ -46,6 +47,7 @@ jobs:
         tag_name: "${{env.VERSION}}"
         files: |
           Publish/Amplitude_Soundboard-x86_64.AppImage
+          Publish/Amplitude_Soundboard_macOS_arm64.tar.gz
           Publish/Amplitude_Soundboard_macOS_x86_64.tar.gz
           Publish/Amplitude_Soundboard_win_x86_64.zip
           Publish/version.txt

--- a/AmplitudeSoundboard.csproj
+++ b/AmplitudeSoundboard.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'win-x64'">$(DefineConstants);Windows</DefineConstants>
-    <DefineConstants Condition="'$(RuntimeIdentifier)' == 'osx-x64'">$(DefineConstants);MacOS</DefineConstants>
+    <DefineConstants Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">$(DefineConstants);MacOS</DefineConstants>
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-x64'">$(DefineConstants);Linux</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -16,7 +16,7 @@
     <AssemblyName>amplitude_soundboard</AssemblyName>
     <RootNamespace>Amplitude</RootNamespace>
     <NeutralLanguage>en</NeutralLanguage>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>AnyCPU;x64;ARM64</Platforms>
     <Version>2.12.0</Version>
     <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
     <PublishTrimmed>true</PublishTrimmed>
@@ -137,7 +137,7 @@
     </Content>
   </ItemGroup>
   <!--MacOS-->
-  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+  <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
     <Content Include="$(ProjectDir)Libraries\BASS\MacOS\libbass.dylib">
       <Link>libbass.dylib</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Helpers/HotkeysManager.cs
+++ b/Helpers/HotkeysManager.cs
@@ -35,7 +35,7 @@ namespace Amplitude.Helpers
         private readonly IKeyboardHook _keyboardHook;
         private readonly Lazy<SoundClipManager> _soundClipManager;
 
-        private IKeyboardHook KeyboardHook => _keyboardHook.Value;
+        private IKeyboardHook KeyboardHook => _keyboardHook;
         private SoundClipManager SoundClipManager => _soundClipManager.Value;
 
         public const string UNBIND_HOTKEY = "UNBIND_HOTKEY";

--- a/Helpers/HotkeysManager.cs
+++ b/Helpers/HotkeysManager.cs
@@ -34,18 +34,17 @@ namespace Amplitude.Helpers
     {
         private readonly IKeyboardHook _keyboardHook;
         private readonly Lazy<SoundClipManager> _soundClipManager;
-        private readonly ISoundEngine _soundEngine;
 
+        private IKeyboardHook KeyboardHook => _keyboardHook.Value;
         private SoundClipManager SoundClipManager => _soundClipManager.Value;
 
         public const string UNBIND_HOTKEY = "UNBIND_HOTKEY";
         public const string MASTER_STOP_SOUND_HOTKEY = "MASTER_STOP_SOUND_HOTKEY";
 
-        public HotkeysManager(IKeyboardHook keyboardHook, Lazy<SoundClipManager> soundClipManager, ISoundEngine soundEngine)
+        public HotkeysManager(IKeyboardHook keyboardHook, Lazy<SoundClipManager> soundClipManager)
         {
             _keyboardHook = keyboardHook;
             _soundClipManager = soundClipManager;
-            _soundEngine = soundEngine;
         }
 
         public Dictionary<string, List<string>> Hotkeys = [];
@@ -70,7 +69,7 @@ namespace Amplitude.Helpers
 
         public bool RecordGlobalStopSoundHotkey(Config config)
         {
-            return _keyboardHook.SetGlobalStopHotkey(config, RecordGlobalStopSoundHotkeyCallback);
+            return KeyboardHook.SetGlobalStopHotkey(config, RecordGlobalStopSoundHotkeyCallback);
         }
 
         public void RecordGlobalStopSoundHotkeyCallback(Config config, string hotkeyString)
@@ -95,7 +94,7 @@ namespace Amplitude.Helpers
 
         public bool RecordSoundClipHotkey(SoundClip clip)
         {
-            return _keyboardHook.SetSoundClipHotkey(clip, RecordSoundClipHotkeyCallback);
+            return KeyboardHook.SetSoundClipHotkey(clip, RecordSoundClipHotkeyCallback);
         }
 
         public void RecordSoundClipHotkeyCallback(SoundClip clip, string hotkeyString)

--- a/Helpers/HotkeysManager.cs
+++ b/Helpers/HotkeysManager.cs
@@ -62,9 +62,9 @@ namespace Amplitude.Helpers
             }
         }
 
-        public void RecordGlobalStopSoundHotkey(Config config)
+        public bool RecordGlobalStopSoundHotkey(Config config)
         {
-            App.KeyboardHook.SetGlobalStopHotkey(config, RecordGlobalStopSoundHotkeyCallback);
+            return App.KeyboardHook.SetGlobalStopHotkey(config, RecordGlobalStopSoundHotkeyCallback);
         }
 
         public void RecordGlobalStopSoundHotkeyCallback(Config config, string hotkeyString)
@@ -87,9 +87,9 @@ namespace Amplitude.Helpers
             }
         }
 
-        public void RecordSoundClipHotkey(SoundClip clip)
+        public bool RecordSoundClipHotkey(SoundClip clip)
         {
-            App.KeyboardHook.SetSoundClipHotkey(clip, RecordSoundClipHotkeyCallback);
+            return App.KeyboardHook.SetSoundClipHotkey(clip, RecordSoundClipHotkeyCallback);
         }
 
         public void RecordSoundClipHotkeyCallback(SoundClip clip, string hotkeyString)

--- a/Helpers/IKeyboardHook.cs
+++ b/Helpers/IKeyboardHook.cs
@@ -27,7 +27,7 @@ namespace Amplitude.Helpers
     public interface IKeyboardHook : IDisposable
     {
         public static abstract IKeyboardHook Instance { get; }
-        public void SetSoundClipHotkey(SoundClip clip, Action<SoundClip, string> callback);
-        public void SetGlobalStopHotkey(Config config, Action<Config, string> callback);
+        public bool SetSoundClipHotkey(SoundClip clip, Action<SoundClip, string> callback);
+        public bool SetGlobalStopHotkey(Config config, Action<Config, string> callback);
     }
 }

--- a/Helpers/SharpKeyboardHook.cs
+++ b/Helpers/SharpKeyboardHook.cs
@@ -23,14 +23,25 @@ using Amplitude.Models;
 using AmplitudeSoundboard;
 using SharpHook;
 using SharpHook.Data;
+using SharpHook.Providers;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Amplitude.Helpers
 {
     public class SharpKeyboardHook : IKeyboardHook
     {
-        private static IGlobalHook sharpHook = new TaskPoolGlobalHook();
+        private const string MacOSAccessibilityMessage =
+            "Hotkeys need macOS Accessibility permission before Amplitude Soundboard can record or trigger keybinds. " +
+            "Open System Settings > Privacy & Security > Accessibility, enable Amplitude Soundboard, then restart the app.";
+
+        private IGlobalHook? sharpHook;
+        private Task? hookTask;
+        private bool hookAvailable;
+        private bool disposed;
+
         private static List<(SoundClip clip, Action<SoundClip, string> callback)> soundClipCallbacks = new();
         private static (Config? config, Action<Config, string> callback) globalStopCallback;
 
@@ -42,9 +53,145 @@ namespace Amplitude.Helpers
 
         private SharpKeyboardHook()
         {
-            sharpHook.KeyPressed += HandleKeyPressed;
-            sharpHook.KeyReleased += HandleKeyReleased;
-            sharpHook.RunAsync();
+            UioHookProvider.Instance.KeyTypedEnabled = false;
+            StartHook(promptForMacOSAccessibility: true, showErrors: false);
+        }
+
+        private bool StartHook(bool promptForMacOSAccessibility, bool showErrors)
+        {
+            if (disposed)
+            {
+                return false;
+            }
+
+            if (hookTask != null && !hookTask.IsCompleted)
+            {
+                return true;
+            }
+
+#if MacOS
+            if (!UioHookProvider.Instance.IsAxApiEnabled(promptForMacOSAccessibility))
+            {
+                hookAvailable = false;
+                if (showErrors)
+                {
+                    ShowAccessibilityError();
+                    OpenAccessibilitySettings();
+                }
+                return false;
+            }
+#endif
+
+            try
+            {
+                sharpHook?.Dispose();
+                sharpHook = new EventLoopGlobalHook(GlobalHookType.Keyboard);
+                sharpHook.HookEnabled += HandleHookEnabled;
+                sharpHook.HookDisabled += HandleHookDisabled;
+                sharpHook.KeyPressed += HandleKeyPressed;
+                sharpHook.KeyReleased += HandleKeyReleased;
+
+                hookTask = sharpHook.RunAsync();
+                hookTask.ContinueWith(HandleHookFailure, TaskContinuationOptions.OnlyOnFaulted);
+                hookAvailable = true;
+                return true;
+            }
+            catch (HookException ex)
+            {
+                HandleHookException(ex, showErrors);
+            }
+            catch (Exception ex)
+            {
+                hookAvailable = false;
+                Debug.WriteLine(ex);
+                if (showErrors)
+                {
+                    App.WindowManager.ShowErrorString($"Hotkeys could not be started: {ex.Message}");
+                }
+            }
+            return false;
+        }
+
+        private void HandleHookEnabled(object? sender, HookEventArgs e)
+        {
+            hookAvailable = true;
+        }
+
+        private void HandleHookDisabled(object? sender, HookEventArgs e)
+        {
+            hookAvailable = false;
+        }
+
+        private void HandleHookFailure(Task task)
+        {
+            hookAvailable = false;
+            if (task.Exception == null)
+            {
+                return;
+            }
+
+            foreach (var exception in task.Exception.Flatten().InnerExceptions)
+            {
+                Debug.WriteLine(exception);
+                if (exception is HookException hookException)
+                {
+                    HandleHookException(hookException, showErrors: false);
+                }
+            }
+        }
+
+        private void HandleHookException(HookException ex, bool showErrors)
+        {
+            hookAvailable = false;
+            Debug.WriteLine(ex);
+#if MacOS
+            if (ex.Result == UioHookResult.ErrorAxApiDisabled)
+            {
+                if (showErrors)
+                {
+                    ShowAccessibilityError();
+                    OpenAccessibilitySettings();
+                }
+                return;
+            }
+#endif
+            if (showErrors)
+            {
+                App.WindowManager.ShowErrorString($"Hotkeys could not be started: {ex.Message}");
+            }
+        }
+
+        private bool EnsureHookAvailable()
+        {
+            if (hookAvailable && hookTask != null && !hookTask.IsCompleted)
+            {
+                return true;
+            }
+
+            return StartHook(promptForMacOSAccessibility: true, showErrors: true);
+        }
+
+        private static void ShowAccessibilityError()
+        {
+            App.WindowManager.ShowErrorString(MacOSAccessibilityMessage);
+        }
+
+        private static void OpenAccessibilitySettings()
+        {
+#if MacOS
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+                    UseShellExecute = true
+                });
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+#endif
         }
 
         private void HandleKeyReleased(object? sender, KeyboardHookEventArgs e)
@@ -221,21 +368,39 @@ namespace Amplitude.Helpers
             return keycode.ToString()[2..];
         }
 
-        public void SetSoundClipHotkey(SoundClip clip, Action<SoundClip, string> callback)
+        public bool SetSoundClipHotkey(SoundClip clip, Action<SoundClip, string> callback)
         {
+            if (!EnsureHookAvailable())
+            {
+                return false;
+            }
+
             soundClipCallbacks.Add((clip, callback));
+            return true;
         }
 
-        public void SetGlobalStopHotkey(Config config, Action<Config, string> callback)
+        public bool SetGlobalStopHotkey(Config config, Action<Config, string> callback)
         {
+            if (!EnsureHookAvailable())
+            {
+                return false;
+            }
+
             globalStopCallback = (config, callback);
+            return true;
         }
 
         public void Dispose()
         {
-            sharpHook.KeyPressed -= HandleKeyPressed;
-            sharpHook.KeyReleased -= HandleKeyReleased;
-            sharpHook.Dispose();
+            disposed = true;
+            if (sharpHook != null)
+            {
+                sharpHook.HookEnabled -= HandleHookEnabled;
+                sharpHook.HookDisabled -= HandleHookDisabled;
+                sharpHook.KeyPressed -= HandleKeyPressed;
+                sharpHook.KeyReleased -= HandleKeyReleased;
+                sharpHook.Dispose();
+            }
         }
     }
 }

--- a/Helpers/SharpKeyboardHook.cs
+++ b/Helpers/SharpKeyboardHook.cs
@@ -180,7 +180,7 @@ namespace Amplitude.Helpers
             }
             catch (Exception ex)
             {
-                WindowManager.ShowErrorString(ex.Message);
+                Locator.Current.GetService<WindowManager>()!.ShowErrorString(ex.Message);
             }
 #endif
         }

--- a/Helpers/SharpKeyboardHook.cs
+++ b/Helpers/SharpKeyboardHook.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
     AmplitudeSoundboard
     Copyright (C) 2021-2026 dan0v
     https://git.dan0v.com/AmplitudeSoundboard
@@ -23,6 +23,7 @@ using Amplitude.Models;
 using SharpHook;
 using SharpHook.Data;
 using SharpHook.Providers;
+using Splat;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -163,7 +164,7 @@ namespace Amplitude.Helpers
 
         private static void ShowMacOSAccessibilityError()
         {
-            WindowManager.ShowErrorString(Localization.Localizer.Instance["MacOSAccessibilityError"]);
+			Locator.Current.GetService<WindowManager>()!.ShowErrorString(Localization.Localizer.Instance["MacOSAccessibilityError"]);
         }
 
         private static void OpenAccessibilitySettings()

--- a/Helpers/SharpKeyboardHook.cs
+++ b/Helpers/SharpKeyboardHook.cs
@@ -27,20 +27,17 @@ using SharpHook.Providers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Amplitude.Helpers
 {
     public class SharpKeyboardHook : IKeyboardHook
     {
-        private const string MacOSAccessibilityMessage =
-            "Hotkeys need macOS Accessibility permission before Amplitude Soundboard can record or trigger keybinds. " +
-            "Open System Settings > Privacy & Security > Accessibility, enable Amplitude Soundboard, then restart the app.";
-
         private IGlobalHook? sharpHook;
         private Task? hookTask;
-        private bool hookAvailable;
-        private bool disposed;
+        private volatile bool hookAvailable;
+        private volatile bool disposed;
 
         private static List<(SoundClip clip, Action<SoundClip, string> callback)> soundClipCallbacks = new();
         private static (Config? config, Action<Config, string> callback) globalStopCallback;
@@ -54,10 +51,10 @@ namespace Amplitude.Helpers
         private SharpKeyboardHook()
         {
             UioHookProvider.Instance.KeyTypedEnabled = false;
-            StartHook(promptForMacOSAccessibility: true, showErrors: false);
+            StartHook();
         }
 
-        private bool StartHook(bool promptForMacOSAccessibility, bool showErrors)
+        private bool StartHook()
         {
             if (disposed)
             {
@@ -70,14 +67,10 @@ namespace Amplitude.Helpers
             }
 
 #if MacOS
-            if (!UioHookProvider.Instance.IsAxApiEnabled(promptForMacOSAccessibility))
+            if (!UioHookProvider.Instance.IsAxApiEnabled(true))
             {
-                hookAvailable = false;
-                if (showErrors)
-                {
-                    ShowAccessibilityError();
-                    OpenAccessibilitySettings();
-                }
+                ShowMacOSAccessibilityError();
+                OpenAccessibilitySettings();
                 return false;
             }
 #endif
@@ -93,21 +86,15 @@ namespace Amplitude.Helpers
 
                 hookTask = sharpHook.RunAsync();
                 hookTask.ContinueWith(HandleHookFailure, TaskContinuationOptions.OnlyOnFaulted);
-                hookAvailable = true;
                 return true;
             }
             catch (HookException ex)
             {
-                HandleHookException(ex, showErrors);
+                HandleHookException(ex);
             }
             catch (Exception ex)
             {
-                hookAvailable = false;
-                Debug.WriteLine(ex);
-                if (showErrors)
-                {
-                    App.WindowManager.ShowErrorString($"Hotkeys could not be started: {ex.Message}");
-                }
+                App.WindowManager.ShowErrorString(string.Format(Localization.Localizer.Instance["HotkeysStartError"], ex.Message));
             }
             return false;
         }
@@ -132,48 +119,45 @@ namespace Amplitude.Helpers
 
             foreach (var exception in task.Exception.Flatten().InnerExceptions)
             {
-                Debug.WriteLine(exception);
                 if (exception is HookException hookException)
                 {
-                    HandleHookException(hookException, showErrors: false);
+                    HandleHookException(hookException);
                 }
             }
         }
 
-        private void HandleHookException(HookException ex, bool showErrors)
+        private void HandleHookException(HookException ex)
         {
             hookAvailable = false;
-            Debug.WriteLine(ex);
 #if MacOS
             if (ex.Result == UioHookResult.ErrorAxApiDisabled)
             {
-                if (showErrors)
-                {
-                    ShowAccessibilityError();
-                    OpenAccessibilitySettings();
-                }
+                ShowMacOSAccessibilityError();
+                OpenAccessibilitySettings();
                 return;
             }
 #endif
-            if (showErrors)
-            {
-                App.WindowManager.ShowErrorString($"Hotkeys could not be started: {ex.Message}");
-            }
+            App.WindowManager.ShowErrorString(string.Format(Localization.Localizer.Instance["HotkeysStartError"], ex.Message));
         }
 
         private bool EnsureHookAvailable()
         {
-            if (hookAvailable && hookTask != null && !hookTask.IsCompleted)
+            if (disposed)
+            {
+                return false;
+            }
+
+            if (hookAvailable)
             {
                 return true;
             }
 
-            return StartHook(promptForMacOSAccessibility: true, showErrors: true);
+            return StartHook();
         }
 
-        private static void ShowAccessibilityError()
+        private static void ShowMacOSAccessibilityError()
         {
-            App.WindowManager.ShowErrorString(MacOSAccessibilityMessage);
+            App.WindowManager.ShowErrorString(Localization.Localizer.Instance["MacOSAccessibilityError"]);
         }
 
         private static void OpenAccessibilitySettings()
@@ -189,7 +173,7 @@ namespace Amplitude.Helpers
             }
             catch (Exception ex)
             {
-                Debug.WriteLine(ex);
+                App.WindowManager.ShowErrorString(ex.Message);
             }
 #endif
         }
@@ -262,19 +246,15 @@ namespace Amplitude.Helpers
 
         private string FullKey(string currentKey)
         {
+            SortedSet<KeyCode> keySetCopy;
             lock (keySetLock)
             {
-                var keySetCopy = new SortedSet<KeyCode>(keySet);
+                keySetCopy = [.. keySet];
             }
 
-            if (keySet.Count > 0)
+            if (keySetCopy.Count > 0)
             {
-                string full = "";
-                foreach (KeyCode keyCode in keySet)
-                {
-                    full += GetFriendlyKeyName(keyCode) + "|";
-                }
-                return full + currentKey;
+                return string.Join("|", keySetCopy.Select(k => GetFriendlyKeyName(k))) + "|" + currentKey;
             }
             else
             {

--- a/Localization/Language.es.resx
+++ b/Localization/Language.es.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>No se pudieron iniciar los atajos de teclado: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>El perfil predeterminado no se puede eliminar</value>
     </data>

--- a/Localization/Language.es.resx
+++ b/Localization/Language.es.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Dispositivo de salida</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>Los atajos de teclado necesitan permiso de Accesibilidad de macOS antes de que Amplitude Soundboard pueda grabar o activar combinaciones de teclas. Abra Configuración del Sistema > Privacidad y Seguridad > Accesibilidad, habilite Amplitude Soundboard y luego reinicie la aplicación.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>No se pudieron iniciar los atajos de teclado: {0}</value>
+    </data>
 </root>

--- a/Localization/Language.hu.resx
+++ b/Localization/Language.hu.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>A gyorsbillentyűk nem indíthatók el: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>Az alapértelmezett profil nem törölhető</value>
     </data>

--- a/Localization/Language.hu.resx
+++ b/Localization/Language.hu.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Kimeneti eszköz</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>A gyorsbillentyűk használatához macOS Akadálymentesítési engedély szükséges. Nyissa meg a Rendszerbeállítások > Adatvédelem és biztonság > Akadálymentesítés menüpontot, engedélyezze az Amplitude Soundboard alkalmazást, majd indítsa újra.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>A gyorsbillentyűk nem indíthatók el: {0}</value>
+    </data>
 </root>

--- a/Localization/Language.it.resx
+++ b/Localization/Language.it.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>Impossibile avviare i tasti rapidi: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>Il profilo predefinito non può essere eliminato</value>
     </data>

--- a/Localization/Language.it.resx
+++ b/Localization/Language.it.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Dispositivo di output</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>I tasti rapidi richiedono l'autorizzazione Accessibilità di macOS prima che Amplitude Soundboard possa registrare o attivare combinazioni di tasti. Apri Impostazioni di Sistema > Privacy e Sicurezza > Accessibilità, abilita Amplitude Soundboard, quindi riavvia l'app.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>Impossibile avviare i tasti rapidi: {0}</value>
+    </data>
 </root>

--- a/Localization/Language.nl.resx
+++ b/Localization/Language.nl.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Uitvoerapparaat</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>Sneltoetsen hebben macOS Toegankelijkheidsmachtiging nodig voordat Amplitude Soundboard toetscombinaties kan opnemen of activeren. Open Systeeminstellingen > Privacy en beveiliging > Toegankelijkheid, schakel Amplitude Soundboard in en start de app opnieuw.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>Sneltoetsen konden niet worden gestart: {0}</value>
+    </data>
 </root>

--- a/Localization/Language.nl.resx
+++ b/Localization/Language.nl.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>Sneltoetsen konden niet worden gestart: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>Het standaardprofiel kan niet worden verwijderd</value>
     </data>

--- a/Localization/Language.pl.resx
+++ b/Localization/Language.pl.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>Nie można uruchomić skrótów klawiszowych: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>Domyślny profil nie może zostać usunięty</value>
     </data>

--- a/Localization/Language.pl.resx
+++ b/Localization/Language.pl.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Urządzenie wyjściowe</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>Skróty klawiszowe wymagają uprawnienia Dostępności macOS, aby Amplitude Soundboard mógł nagrywać lub aktywować kombinacje klawiszy. Otwórz Ustawienia systemu > Prywatność i bezpieczeństwo > Dostępność, włącz Amplitude Soundboard, a następnie uruchom ponownie aplikację.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>Nie można uruchomić skrótów klawiszowych: {0}</value>
+    </data>
 </root>

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>Hotkeys could not be started: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>The default Output Profile cannot be deleted</value>
     </data>

--- a/Localization/Language.resx
+++ b/Localization/Language.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Output device</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>Hotkeys need macOS Accessibility permission before Amplitude Soundboard can record or trigger keybinds. Open System Settings > Privacy and Security > Accessibility, enable Amplitude Soundboard, then restart the app.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>Hotkeys could not be started: {0}</value>
+    </data>
 </root>

--- a/Localization/Language.ru.resx
+++ b/Localization/Language.ru.resx
@@ -431,6 +431,7 @@
     </data>
     <data name="HotkeysStartError" xml:space="preserve">
         <value>Не удалось запустить горячие клавиши: {0}</value>
+    </data>
     <data name="DefaultProfileCannotBeDeleted" xml:space="preserve">
         <value>Профиль по умолчанию не может быть удален</value>
     </data>

--- a/Localization/Language.ru.resx
+++ b/Localization/Language.ru.resx
@@ -426,4 +426,10 @@
     <data name="OutputSettingsDeviceLabel" xml:space="preserve">
         <value>Устройство вывода</value>
     </data>
+    <data name="MacOSAccessibilityError" xml:space="preserve">
+        <value>Горячие клавиши требуют разрешения Универсального доступа macOS, прежде чем Amplitude Soundboard сможет записывать или активировать сочетания клавиш. Откройте Системные настройки > Конфиденциальность и безопасность > Универсальный доступ, включите Amplitude Soundboard и перезапустите приложение.</value>
+    </data>
+    <data name="HotkeysStartError" xml:space="preserve">
+        <value>Не удалось запустить горячие клавиши: {0}</value>
+    </data>
 </root>

--- a/Publish/MacOS/MacOS.sh
+++ b/Publish/MacOS/MacOS.sh
@@ -15,18 +15,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '
 
-ORIGIN="$(pwd)"
-cd "../.."
-dotnet publish -r osx-x64 -c Release -p:SelfContained=True -o bin/Release/net10.0/publishMac
-cd "$ORIGIN"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RID="${1:-osx-arm64}"
+
+case "$RID" in
+    osx-arm64)
+        APP_TAR_NAME2="macOS_arm64"
+        ;;
+    osx-x64)
+        APP_TAR_NAME2="macOS_x86_64"
+        ;;
+    *)
+        echo "Unsupported macOS RID: $RID"
+        exit 1
+        ;;
+esac
+
+PUBLISH_OUTPUT_SUBDIRECTORY="publishMac-$RID"
+cd "$ROOT_DIR"
+dotnet publish "$ROOT_DIR/AmplitudeSoundboard.csproj" -r "$RID" -c Release -p:SelfContained=True -o "bin/Release/net10.0/$PUBLISH_OUTPUT_SUBDIRECTORY"
 
 APP_NAME="Amplitude Soundboard.app"
-APP_OUTPUT_PATH="Output"
+APP_OUTPUT_PATH="$SCRIPT_DIR/Output"
 APP_TAR_NAME1="Amplitude_Soundboard_"
-APP_TAR_NAME2="macOS_x86_64"
-PUBLISH_OUTPUT_DIRECTORY="../../bin/Release/net10.0/publishMac/."
-INFO_PLIST="Info.plist"
-ICON_FILE="Icon.icns"
+PUBLISH_OUTPUT_DIRECTORY="$ROOT_DIR/bin/Release/net10.0/$PUBLISH_OUTPUT_SUBDIRECTORY/."
+INFO_PLIST="$SCRIPT_DIR/Info.plist"
+ICON_FILE="$SCRIPT_DIR/Icon.icns"
+ICON_FILE_NAME="Icon.icns"
 
 if [ -d "$APP_OUTPUT_PATH" ]
 then
@@ -40,7 +56,7 @@ mkdir "$APP_OUTPUT_PATH/$APP_NAME/Contents"
 mkdir "$APP_OUTPUT_PATH/$APP_NAME/Contents/MacOS"
 mkdir "$APP_OUTPUT_PATH/$APP_NAME/Contents/Resources"
 
-VERSION=$(cat ../version.txt | sed 's/ *$//g' | sed 's/\r//' | sed ':a;N;$!ba;s/\n//g')
+VERSION="$(tr -d '\r\n' < "$ROOT_DIR/Publish/version.txt")"
 
 cp "$INFO_PLIST" "$APP_OUTPUT_PATH/$APP_NAME/Contents/InfoTEMP.plist"
 
@@ -48,11 +64,11 @@ cp "$INFO_PLIST" "$APP_OUTPUT_PATH/$APP_NAME/Contents/InfoTEMP.plist"
 sed 's/{VERSION}/'"$VERSION"'/g' "$APP_OUTPUT_PATH/$APP_NAME/Contents/InfoTEMP.plist" > "$APP_OUTPUT_PATH/$APP_NAME/Contents/Info.plist"
 rm "$APP_OUTPUT_PATH/$APP_NAME/Contents/InfoTEMP.plist"
 
-unzip -o "$ICON_FILE".zip "$ICON_FILE"
+unzip -o "$ICON_FILE".zip -d "$SCRIPT_DIR"
 
-cp "$ICON_FILE" "$APP_OUTPUT_PATH/$APP_NAME/Contents/Resources/$ICON_FILE"
+cp "$ICON_FILE" "$APP_OUTPUT_PATH/$APP_NAME/Contents/Resources/$ICON_FILE_NAME"
 cp -a "$PUBLISH_OUTPUT_DIRECTORY" "$APP_OUTPUT_PATH/$APP_NAME/Contents/MacOS"
 chmod +x "$APP_OUTPUT_PATH/$APP_NAME/Contents/MacOS/amplitude_soundboard"
 cd "$APP_OUTPUT_PATH"
 tar -czvf "$APP_TAR_NAME1$APP_TAR_NAME2.tar.gz" "$APP_NAME/"
-mv "$APP_TAR_NAME1$APP_TAR_NAME2.tar.gz" ../../"$APP_TAR_NAME1$APP_TAR_NAME2.tar.gz"
+mv "$APP_TAR_NAME1$APP_TAR_NAME2.tar.gz" "$ROOT_DIR/Publish/$APP_TAR_NAME1$APP_TAR_NAME2.tar.gz"

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@
 2. Run executable (`amplitude_soundboard.exe`).
 3. If you would like to play sound through an input device like a microphone, set up a program like [Virtual Audio Cable](https://vac.muzychenko.net/en/download.htm) and set the newly created virtual cable as your clip output device.
 
-### MacOS *(x64)*
-1. Download and unzip [latest MacOS build](https://github.com/dan0v/AmplitudeSoundboard/releases/latest/download/Amplitude_Soundboard_macOS_x86_64.tar.gz) from the [Releases page](https://git.dan0v.com/AmplitudeSoundboard/releases/).
+### MacOS *(Apple Silicon / Intel)*
+1. Download the appropriate MacOS build from the [Releases page](https://git.dan0v.com/AmplitudeSoundboard/releases/).
+ - Apple Silicon: `Amplitude_Soundboard_macOS_arm64.tar.gz`
+ - Intel: `Amplitude_Soundboard_macOS_x86_64.tar.gz`
 2. Run executable (`Amplitude Soundboard.app`).
  - If a security warning blocks the app from running, open `System Preferences -> Privacy & Security -> General` and click `Open Anyway`. This is due to not signing the app with an Apple Developer ID.
  - In order to use hotkeys, Amplitude Soundboard must be given accessibility permission to control your computer. This can be done under `System Preferences -> Privacy & Security -> Accessibility`. A popup should take you directly to this option at application startup. Amplitude Soundboard will need to be restarted after granting permissions for hotkeys to start working.
@@ -54,7 +56,7 @@
 A dialog automatically notifies users of available updates at application startup. To automatically update, click `Update`, or, to manually update, just download the [latest Windows build](https://git.dan0v.com/AmplitudeSoundboard/releases/latest/download/Amplitude_Soundboard_win_x86_64.zip) from the [Releases page](https://git.dan0v.com/AmplitudeSoundboard/releases/) and replace your `amplitude_soundboard.exe` with the new version.
 
 ### MacOS
-A dialog automatically notifies users of available updates at application startup. To manually update, just download the [latest MacOS build](https://github.com/dan0v/AmplitudeSoundboard/releases/latest/download/Amplitude_Soundboard_macOS_x86_64.tar.gz) from the [Releases page](https://git.dan0v.com/AmplitudeSoundboard/releases/) and replace your `Amplitude Soundboard.app` with the new version.
+A dialog automatically notifies users of available updates at application startup. To manually update, download the appropriate Apple Silicon or Intel MacOS build from the [Releases page](https://git.dan0v.com/AmplitudeSoundboard/releases/) and replace your `Amplitude Soundboard.app` with the new version.
 
 ### Linux
 A dialog automatically notifies users of available updates at application startup. To manually update, just download the [latest Linux build](https://github.com/dan0v/AmplitudeSoundboard/releases/latest/download/Amplitude_Soundboard-x86_64.AppImage) from the [Releases page](https://git.dan0v.com/AmplitudeSoundboard/releases/) and replace your `Amplitude_Soundboard-x86_64.AppImage` with the new version. On Arch Linux, you can use the [`amplitude-soundboard-appimage`](https://aur.archlinux.org/packages/amplitude-soundboard-appimage) package in the AUR.

--- a/ViewModels/EditSoundClipViewModel.cs
+++ b/ViewModels/EditSoundClipViewModel.cs
@@ -292,9 +292,14 @@ namespace Amplitude.ViewModels
 
         public void RecordHotkey()
         {
+            var previousHotkey = Model.Hotkey;
             Model.Hotkey = Localization.Localizer.Instance["HotkeyCancelPlaceholder"];
             WaitingForHotkey = true;
-            App.HotkeysManager.RecordSoundClipHotkey(Model);
+            if (!App.HotkeysManager.RecordSoundClipHotkey(Model))
+            {
+                Model.Hotkey = previousHotkey;
+                WaitingForHotkey = false;
+            }
         }
 
         public override void Dispose()

--- a/ViewModels/GlobalSettingsViewModel.cs
+++ b/ViewModels/GlobalSettingsViewModel.cs
@@ -68,9 +68,14 @@ namespace Amplitude.ViewModels
 
         public void RecordHotkey()
         {
+            var previousHotkey = Model.GlobalKillAudioHotkey;
             Model.GlobalKillAudioHotkey = Localization.Localizer.Instance["HotkeyCancelPlaceholder"];
             WaitingForHotkey = true;
-            HotkeysManager.RecordGlobalStopSoundHotkey(Model);
+            if (!HotkeysManager.RecordGlobalStopSoundHotkey(Model))
+            {
+                Model.GlobalKillAudioHotkey = previousHotkey;
+                WaitingForHotkey = false;
+            }
         }
 
         public void SaveConfig()


### PR DESCRIPTION
## Summary

This PR adds native Apple Silicon macOS packaging support while keeping the existing Intel macOS package, and improves macOS hotkey handling when Accessibility permission is missing.

Changes included:

- Add `osx-arm64` as a macOS runtime path in the project file.
- Include the existing macOS BASS dylibs for both `osx-x64` and `osx-arm64` builds.
- Update `Publish/MacOS/MacOS.sh` so it can build either `osx-x64` or `osx-arm64`, defaults to `osx-arm64`, and writes architecture-specific archives.
- Update the release workflow to publish both `Amplitude_Soundboard_macOS_x86_64.tar.gz` and `Amplitude_Soundboard_macOS_arm64.tar.gz`.
- Update README macOS install/update wording for Apple Silicon and Intel builds.
- Make SharpHook startup failures visible on macOS when Accessibility permission is missing, and restore the hotkey UI state instead of leaving keybind recording stuck.

## Why

The current macOS release artifact is Intel-only. On Apple Silicon, .NET, Avalonia, SharpHook, and the bundled macOS audio libraries can all run natively as ARM64, so the app does not need a rewrite to Swift/SwiftUI to support native Apple Silicon builds.

The hotkey change fixes a related macOS UX issue found while testing the ARM64 app: if global keyboard hooks cannot start because Accessibility permission is missing, recording a keybind silently waits forever. This now shows a clear permission message and opens the relevant macOS settings page.

## Validation

Tested locally on an Apple Silicon Mac:

- `dotnet build AmplitudeSoundboard.csproj -c Release -r osx-arm64` succeeds.
- `bash Publish/MacOS/MacOS.sh osx-arm64` succeeds.
- `bash Publish/MacOS/MacOS.sh osx-x64` succeeds.
- Generated ARM64 app executable verifies as `Mach-O 64-bit executable arm64`.
- Generated ARM64 `libuiohook.dylib` verifies as `Mach-O 64-bit dynamically linked shared library arm64`.
- Generated Intel app executable verifies as `Mach-O 64-bit executable x86_64`.
- Generated Intel `libuiohook.dylib` verifies as `Mach-O 64-bit dynamically linked shared library x86_64`.
- GUI smoke test passed locally for launch and the missing-Accessibility hotkey path: the app shows guidance instead of getting stuck in keybind recording.

Existing warnings remain during build/publish, including the transitive `Tmds.DBus.Protocol` NU1903 advisory warning and existing Avalonia/trim/nullability warnings.

## Note

This PR was prepared with help from OpenAI Codex. The changes were tested locally on an Apple Silicon Mac and are working in that local environment, but of course please review and accept/reject based on what fits the project.
